### PR TITLE
refactor(notion): redesign with interfaces, centralized client, and full API coverage

### DIFF
--- a/notion/api_test.go
+++ b/notion/api_test.go
@@ -1,0 +1,879 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// DatabaseManager tests
+// =============================================================================
+
+func TestDatabaseManager_Create(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/databases", r.URL.Path)
+
+		body := readBody(t, r)
+		require.NotNil(t, body)
+		assert.Equal(t, "database_id", body["parent"].(map[string]any)["type"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleDatabaseJSON())) //nolint:errcheck
+	})
+
+	dm := &DatabaseManager{client: client}
+	db, err := dm.Create(testContext(), ParentRef{Type: "database_id", DatabaseID: "db-parent"}, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "database", db.Object)
+	assert.Equal(t, "db-123", db.ID)
+}
+
+func TestDatabaseManager_Retrieve(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/databases/db-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleDatabaseJSON())) //nolint:errcheck
+	})
+
+	dm := &DatabaseManager{client: client}
+	db, err := dm.Retrieve(testContext(), "db-123")
+	require.NoError(t, err)
+	assert.Equal(t, "database", db.Object)
+	assert.Equal(t, "db-123", db.ID)
+	assert.Equal(t, "https://notion.so/db-123", db.URL)
+}
+
+func TestDatabaseManager_Query_SinglePage(t *testing.T) {
+	callCount := 0
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.True(t, strings.HasPrefix(r.URL.Path, "/v1/databases/db-123/query"))
+
+		callCount++
+		pages := []map[string]any{
+			{
+				"object": "page", "id": "page-1",
+				"created_time": "2024-01-01T00:00:00Z",
+				"created_by":   map[string]any{"object": "user", "id": "user-1"},
+			},
+		}
+		jsonRespond(w, http.StatusOK, paginatedResponse(pages, false, ""))
+	})
+
+	dm := &DatabaseManager{client: client}
+	pages, err := dm.Query(testContext(), "db-123", nil)
+	require.NoError(t, err)
+	assert.Len(t, pages, 1)
+	assert.Equal(t, "page-1", pages[0].ID)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestDatabaseManager_Query_MultiplePages(t *testing.T) {
+	callCount := 0
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		body := readBody(t, r)
+		var pages []map[string]any
+
+		if callCount == 1 {
+			// First call: no start_cursor expected.
+			_, hasCursor := body["start_cursor"]
+			assert.False(t, hasCursor)
+			pages = []map[string]any{
+				{"object": "page", "id": "page-1", "created_time": "2024-01-01T00:00:00Z",
+					"created_by": map[string]any{"object": "user", "id": "u1"}},
+				{"object": "page", "id": "page-2", "created_time": "2024-01-01T00:00:00Z",
+					"created_by": map[string]any{"object": "user", "id": "u1"}},
+			}
+			jsonRespond(w, http.StatusOK, paginatedResponse(pages, true, "cursor-abc"))
+		} else {
+			// Second call: start_cursor should be set.
+			assert.Equal(t, "cursor-abc", body["start_cursor"])
+			pages = []map[string]any{
+				{"object": "page", "id": "page-3", "created_time": "2024-01-01T00:00:00Z",
+					"created_by": map[string]any{"object": "user", "id": "u1"}},
+			}
+			jsonRespond(w, http.StatusOK, paginatedResponse(pages, false, ""))
+		}
+	})
+
+	dm := &DatabaseManager{client: client}
+	pages, err := dm.Query(testContext(), "db-123", &Condition{PageSize: 2})
+	require.NoError(t, err)
+	assert.Len(t, pages, 3)
+	assert.Equal(t, "page-1", pages[0].ID)
+	assert.Equal(t, "page-2", pages[1].ID)
+	assert.Equal(t, "page-3", pages[2].ID)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestDatabaseManager_Query_WithFilter(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+		assert.NotNil(t, body["filter"])
+
+		pages := []map[string]any{
+			{"object": "page", "id": "page-1", "created_time": "2024-01-01T00:00:00Z",
+				"created_by": map[string]any{"object": "user", "id": "u1"}},
+		}
+		jsonRespond(w, http.StatusOK, paginatedResponse(pages, false, ""))
+	})
+
+	dm := &DatabaseManager{client: client}
+	cond := &Condition{
+		PageSize: 100,
+		Filter:   &FilterCondition{FilterSingleCondition: FilterSingleCondition{Property: "Status", Select: &SelectFilter{Equals: "Done"}}},
+	}
+	pages, err := dm.Query(testContext(), "db-123", cond)
+	require.NoError(t, err)
+	assert.Len(t, pages, 1)
+}
+
+func TestDatabaseManager_Update(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/v1/databases/db-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleDatabaseJSON())) //nolint:errcheck
+	})
+
+	dm := &DatabaseManager{client: client}
+	payload := strings.NewReader(`{"title": [{"type": "text", "text": {"content": "Updated"}}]}`)
+	db, err := dm.Update(testContext(), "db-123", payload)
+	require.NoError(t, err)
+	assert.Equal(t, "db-123", db.ID)
+}
+
+// =============================================================================
+// PageManager tests
+// =============================================================================
+
+func TestPageManager_Create(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/pages", r.URL.Path)
+
+		body := readBody(t, r)
+		require.NotNil(t, body)
+		parent, ok := body["parent"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "database_id", parent["type"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(samplePageJSON())) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	page, err := pm.Create(testContext(), ParentRef{Type: "database_id", DatabaseID: "db-123"})
+	require.NoError(t, err)
+	assert.Equal(t, "page", page.Object)
+	assert.Equal(t, "page-123", page.ID)
+}
+
+func TestPageManager_Retrieve(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/pages/page-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(samplePageJSON())) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	page, err := pm.Retrieve(testContext(), "page-123")
+	require.NoError(t, err)
+	assert.Equal(t, "page-123", page.ID)
+	assert.Equal(t, "page", page.Object)
+	assert.False(t, page.Archived)
+}
+
+func TestPageManager_Update(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/v1/pages/page-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(samplePageJSON())) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	page, err := pm.Update(testContext(), "page-123")
+	require.NoError(t, err)
+	assert.Equal(t, "page-123", page.ID)
+}
+
+func TestPageManager_Trash(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/v1/pages/page-123", r.URL.Path)
+
+		body := readBody(t, r)
+		assert.Equal(t, true, body["in_trash"])
+
+		// Return a page marked as in_trash.
+		resp := `{
+			"object": "page",
+			"id": "page-123",
+			"created_time": "2024-01-01T00:00:00Z",
+			"created_by": {"object": "user", "id": "user-1"},
+			"last_edited_time": "2024-01-02T00:00:00Z",
+			"last_edited_by": {"object": "user", "id": "user-2"},
+			"in_trash": true
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp)) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	page, err := pm.Trash(testContext(), "page-123")
+	require.NoError(t, err)
+	assert.Equal(t, "page-123", page.ID)
+	assert.True(t, page.InTrash)
+}
+
+func TestPageManager_RetrieveProperty(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/pages/page-123/properties/prop-1", r.URL.Path)
+
+		resp := `{
+			"object": "property_item",
+			"id": "prop-1",
+			"type": "title",
+			"title": [{"type": "text", "text": {"content": "Hello"}, "plain_text": "Hello"}]
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp)) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	prop, err := pm.RetrieveProperty(testContext(), "page-123", "prop-1")
+	require.NoError(t, err)
+	assert.Equal(t, "prop-1", prop.ID)
+	assert.Equal(t, PropertyType("title"), prop.Type)
+}
+
+// =============================================================================
+// BlockManager tests
+// =============================================================================
+
+func TestBlockManager_Retrieve(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/blocks/block-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleBlockJSON())) //nolint:errcheck
+	})
+
+	bm := &BlockManager{client: client}
+	block, err := bm.Retrieve(testContext(), "block-123")
+	require.NoError(t, err)
+	assert.Equal(t, "block", block.Object)
+	assert.Equal(t, "block-123", block.ID)
+	assert.Equal(t, "paragraph", block.Type)
+	assert.NotNil(t, block.Paragraph)
+}
+
+func TestBlockManager_Update(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/v1/blocks/block-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleBlockJSON())) //nolint:errcheck
+	})
+
+	bm := &BlockManager{client: client}
+	block := &Block{Type: "paragraph", Paragraph: &RichTextBlock{RichText: []TextObject{{Text: TextItem{Content: "updated"}}}}}
+	result, err := bm.Update(testContext(), "block-123", block)
+	require.NoError(t, err)
+	assert.Equal(t, "block-123", result.ID)
+}
+
+func TestBlockManager_Delete(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/v1/blocks/block-123", r.URL.Path)
+
+		// Notion returns the deleted block in trash.
+		resp := `{
+			"object": "block",
+			"id": "block-123",
+			"type": "paragraph",
+			"created_time": "2024-01-01T00:00:00Z",
+			"created_by": {"object": "user", "id": "user-1"},
+			"last_edited_time": "2024-01-02T00:00:00Z",
+			"last_edited_by": {"object": "user", "id": "user-2"},
+			"has_children": false,
+			"in_trash": true,
+			"paragraph": {"rich_text": []}
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp)) //nolint:errcheck
+	})
+
+	bm := &BlockManager{client: client}
+	block, err := bm.Delete(testContext(), "block-123")
+	require.NoError(t, err)
+	assert.Equal(t, "block-123", block.ID)
+	assert.True(t, block.InTrash)
+}
+
+func TestBlockManager_Children_SinglePage(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/blocks/block-parent/children", r.URL.Path)
+
+		blocks := []map[string]any{
+			{
+				"object": "block", "id": "child-1", "type": "paragraph",
+				"created_time": "2024-01-01T00:00:00Z",
+				"created_by":   map[string]any{"object": "user", "id": "u1"},
+				"last_edited_time": "2024-01-01T00:00:00Z",
+				"last_edited_by":   map[string]any{"object": "user", "id": "u1"},
+				"has_children":     false,
+				"paragraph":        map[string]any{"rich_text": []any{}},
+			},
+		}
+		jsonRespond(w, http.StatusOK, paginatedResponse(blocks, false, ""))
+	})
+
+	bm := &BlockManager{client: client}
+	blocks, err := bm.Children(testContext(), "block-parent", nil)
+	require.NoError(t, err)
+	assert.Len(t, blocks, 1)
+	assert.Equal(t, "child-1", blocks[0].ID)
+}
+
+func TestBlockManager_Children_Pagination(t *testing.T) {
+	callCount := 0
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		blocks := []map[string]any{
+			{
+				"object": "block", "id": fmt.Sprintf("child-%d", callCount),
+				"type": "paragraph", "created_time": "2024-01-01T00:00:00Z",
+				"created_by":       map[string]any{"object": "user", "id": "u1"},
+				"last_edited_time": "2024-01-01T00:00:00Z",
+				"last_edited_by":   map[string]any{"object": "user", "id": "u1"},
+				"has_children":     false,
+				"paragraph":        map[string]any{"rich_text": []any{}},
+			},
+		}
+
+		if callCount == 1 {
+			jsonRespond(w, http.StatusOK, paginatedResponse(blocks, true, "next-cursor"))
+		} else {
+			jsonRespond(w, http.StatusOK, paginatedResponse(blocks, false, ""))
+		}
+	})
+
+	bm := &BlockManager{client: client}
+	blocks, err := bm.Children(testContext(), "block-parent", nil)
+	require.NoError(t, err)
+	assert.Len(t, blocks, 2)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestBlockManager_AppendChildren(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/blocks/block-parent/children", r.URL.Path)
+
+		body := readBody(t, r)
+		children, ok := body["children"].([]any)
+		require.True(t, ok)
+		assert.Len(t, children, 1)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleBlockJSON())) //nolint:errcheck
+	})
+
+	bm := &BlockManager{client: client}
+	children := []Block{
+		{Type: "paragraph", Paragraph: &RichTextBlock{RichText: []TextObject{{Text: TextItem{Content: "Hello"}}}}},
+	}
+	block, err := bm.AppendChildren(testContext(), "block-parent", children)
+	require.NoError(t, err)
+	assert.Equal(t, "block-123", block.ID)
+}
+
+// =============================================================================
+// SearchManager tests
+// =============================================================================
+
+func TestSearchManager_Search_WithQuery(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/search", r.URL.Path)
+
+		body := readBody(t, r)
+		assert.Equal(t, "test query", body["query"])
+
+		results := []json.RawMessage{
+			[]byte(`{"object": "page", "id": "result-1"}`),
+		}
+		jsonRespond(w, http.StatusOK, paginatedResponse(results, false, ""))
+	})
+
+	sm := &SearchManager{client: client}
+	resp, err := sm.Search(testContext(), "test query", nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Results, 1)
+	assert.False(t, resp.HasMore)
+}
+
+func TestSearchManager_Search_WithFilter(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+		assert.Equal(t, "test", body["query"])
+		filter, ok := body["filter"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "object", filter["property"])
+		assert.Equal(t, "database", filter["value"])
+
+		results := []json.RawMessage{}
+		jsonRespond(w, http.StatusOK, paginatedResponse(results, false, ""))
+	})
+
+	sm := &SearchManager{client: client}
+	resp, err := sm.Search(testContext(), "test", &SearchFilter{Property: "object", Value: "database"})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Results)
+}
+
+func TestSearchManager_Search_EmptyQuery(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+		// Empty query should not be included in body.
+		_, hasQuery := body["query"]
+		assert.False(t, hasQuery)
+
+		results := []json.RawMessage{}
+		jsonRespond(w, http.StatusOK, paginatedResponse(results, false, ""))
+	})
+
+	sm := &SearchManager{client: client}
+	resp, err := sm.Search(testContext(), "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Results)
+}
+
+// =============================================================================
+// UserManager tests
+// =============================================================================
+
+func TestUserManager_Me(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/users/me", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleUserJSON())) //nolint:errcheck
+	})
+
+	um := &UserManager{client: client}
+	user, err := um.Me(testContext())
+	require.NoError(t, err)
+	assert.Equal(t, "user", user.Object)
+	assert.Equal(t, "user-123", user.ID)
+	assert.Equal(t, "Test User", user.Name)
+}
+
+func TestUserManager_Retrieve(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/users/user-123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleUserJSON())) //nolint:errcheck
+	})
+
+	um := &UserManager{client: client}
+	user, err := um.Retrieve(testContext(), "user-123")
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", user.ID)
+}
+
+func TestUserManager_List(t *testing.T) {
+	callCount := 0
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/users", r.URL.Path)
+
+		callCount++
+		users := []map[string]any{
+			{"object": "user", "id": fmt.Sprintf("user-%d", callCount), "name": "User"},
+		}
+
+		if callCount == 1 {
+			jsonRespond(w, http.StatusOK, paginatedResponse(users, true, "cursor-next"))
+		} else {
+			jsonRespond(w, http.StatusOK, paginatedResponse(users, false, ""))
+		}
+	})
+
+	um := &UserManager{client: client}
+	users, err := um.List(testContext())
+	require.NoError(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, 2, callCount)
+}
+
+// =============================================================================
+// CommentManager tests
+// =============================================================================
+
+func TestCommentManager_List(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/comments", r.URL.Path)
+		assert.Equal(t, "block-123", r.URL.Query().Get("block_id"))
+
+		comments := []map[string]any{
+			{
+				"object": "comment", "id": "comment-1",
+				"created_time": "2024-01-01T00:00:00Z",
+				"created_by":   map[string]any{"object": "user", "id": "user-1"},
+				"rich_text":    []map[string]any{{"type": "text", "text": map[string]any{"content": "hello"}}},
+			},
+		}
+		jsonRespond(w, http.StatusOK, paginatedResponse(comments, false, ""))
+	})
+
+	cm := &CommentManager{client: client}
+	comments, err := cm.List(testContext(), "block-123")
+	require.NoError(t, err)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "comment-1", comments[0].ID)
+}
+
+func TestCommentManager_Create(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		verifyAuth(t, r)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/comments", r.URL.Path)
+
+		body := readBody(t, r)
+		require.NotNil(t, body["parent"])
+		require.NotNil(t, body["rich_text"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleCommentJSON())) //nolint:errcheck
+	})
+
+	cm := &CommentManager{client: client}
+	comment, err := cm.Create(testContext(), ParentRef{Type: "page_id", PageID: "page-123"}, []TextObject{
+		{Text: TextItem{Content: "Nice work!"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "comment", comment.Object)
+	assert.Equal(t, "comment-123", comment.ID)
+}
+
+// =============================================================================
+// Error handling tests
+// =============================================================================
+
+func TestError_Unauthorized(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusUnauthorized, "unauthorized", "Invalid API token")
+	})
+
+	dm := &DatabaseManager{client: client}
+	db, err := dm.Retrieve(testContext(), "db-123")
+	require.Error(t, err)
+	assert.Nil(t, db)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.Status)
+	assert.Equal(t, "unauthorized", apiErr.Code)
+	assert.Equal(t, "Invalid API token", apiErr.Message)
+}
+
+func TestError_RateLimited(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"object": "error", "status": 429, "code": "rate_limited", "message": "Speed limit"}`)) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	page, err := pm.Retrieve(testContext(), "page-123")
+	require.Error(t, err)
+	assert.Nil(t, page)
+	assert.ErrorIs(t, err, ErrRateLimited)
+}
+
+func TestError_NotFound(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusNotFound, "object_not_found", "Could not find page with ID: page-missing")
+	})
+
+	pm := &PageManager{client: client}
+	page, err := pm.Retrieve(testContext(), "page-missing")
+	require.Error(t, err)
+	assert.Nil(t, page)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.Status)
+	assert.Equal(t, "object_not_found", apiErr.Code)
+}
+
+func TestError_InternalServerError_PlainText(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error")) //nolint:errcheck
+	})
+
+	bm := &BlockManager{client: client}
+	block, err := bm.Retrieve(testContext(), "block-123")
+	require.Error(t, err)
+	assert.Nil(t, block)
+	assert.Contains(t, err.Error(), "notion api error: [500]")
+}
+
+func TestError_BadRequest(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusBadRequest, "validation_error", "Invalid request body")
+	})
+
+	sm := &SearchManager{client: client}
+	resp, err := sm.Search(testContext(), "test", nil)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusBadRequest, apiErr.Status)
+	assert.Equal(t, "validation_error", apiErr.Code)
+}
+
+func TestError_Forbidden(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusForbidden, "restricted_resource", "Access denied")
+	})
+
+	um := &UserManager{client: client}
+	user, err := um.Retrieve(testContext(), "user-123")
+	require.Error(t, err)
+	assert.Nil(t, user)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.Status)
+}
+
+// =============================================================================
+// Error propagation through manager wrappers
+// =============================================================================
+
+func TestDatabaseManager_Retrieve_ErrorWrapped(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusNotFound, "object_not_found", "Database not found")
+	})
+
+	dm := &DatabaseManager{client: client}
+	_, err := dm.Retrieve(testContext(), "db-nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retrieve database db-nonexistent")
+}
+
+func TestPageManager_Create_ErrorWrapped(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusBadRequest, "validation_error", "Invalid parent")
+	})
+
+	pm := &PageManager{client: client}
+	_, err := pm.Create(testContext(), ParentRef{Type: "page_id", PageID: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create page")
+}
+
+func TestBlockManager_Delete_ErrorWrapped(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusNotFound, "object_not_found", "Block not found")
+	})
+
+	bm := &BlockManager{client: client}
+	_, err := bm.Delete(testContext(), "block-nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete block block-nonexistent")
+}
+
+func TestUserManager_Me_ErrorWrapped(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusUnauthorized, "unauthorized", "Bad token")
+	})
+
+	um := &UserManager{client: client}
+	_, err := um.Me(testContext())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retrieve current user")
+}
+
+func TestCommentManager_Create_ErrorWrapped(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		errorRespond(w, http.StatusBadRequest, "validation_error", "Missing parent")
+	})
+
+	cm := &CommentManager{client: client}
+	_, err := cm.Create(testContext(), ParentRef{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create comment")
+}
+
+// =============================================================================
+// Context cancellation test
+// =============================================================================
+
+func TestContext_Cancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// This should never be called.
+		t.Error("request should not reach server after context cancellation")
+	})
+
+	pm := &PageManager{client: client}
+	_, err := pm.Retrieve(ctx, "page-123")
+	require.Error(t, err)
+}
+
+// =============================================================================
+// Manager.WithLimiter test
+// =============================================================================
+
+func TestManager_WithLimiter(t *testing.T) {
+	mgr := NewManager("2022-06-28", "test-token")
+	newMgr := mgr.WithLimiter(defaultLimiter())
+	assert.NotNil(t, newMgr)
+	assert.NotNil(t, newMgr.client)
+	// Original manager should be unchanged.
+	assert.NotNil(t, mgr.client)
+}
+
+// =============================================================================
+// Request body verification tests
+// =============================================================================
+
+func TestPageManager_Create_WithProperties(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+		require.NotNil(t, body)
+
+		parent, ok := body["parent"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "database_id", parent["type"])
+		assert.Equal(t, "db-parent", parent["database_id"])
+
+		props, ok := body["properties"].(map[string]any)
+		require.True(t, ok)
+		assert.NotNil(t, props["Name"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(samplePageJSON())) //nolint:errcheck
+	})
+
+	pm := &PageManager{client: client}
+	titleData, _ := json.Marshal([]TextObject{{Text: TextItem{Content: "Test Page"}, PlainText: "Test Page"}})
+	page, err := pm.Create(
+		testContext(),
+		ParentRef{Type: "database_id", DatabaseID: "db-parent"},
+		&Property{Name: "Name", Type: TitleProp, Title: titleData},
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, page)
+}
+
+func TestDatabaseManager_Update_WithPayload(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Read raw body since it's passed as io.Reader.
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "Updated Title")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleDatabaseJSON())) //nolint:errcheck
+	})
+
+	dm := &DatabaseManager{client: client}
+	payload := strings.NewReader(`{"title": [{"type": "text", "text": {"content": "Updated Title"}}]}`)
+	db, err := dm.Update(testContext(), "db-123", payload)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+}
+
+func TestDatabaseManager_Update_NilPayload(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(sampleDatabaseJSON())) //nolint:errcheck
+	})
+
+	dm := &DatabaseManager{client: client}
+	db, err := dm.Update(testContext(), "db-123", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+}
+
+// =============================================================================
+// Query with filter_properties query params
+// =============================================================================
+
+func TestDatabaseManager_Query_WithFilterProperties(t *testing.T) {
+	_, client := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		// The path should include filter_properties query param.
+		assert.Contains(t, r.URL.RawQuery, "filter_properties")
+
+		pages := []map[string]any{}
+		jsonRespond(w, http.StatusOK, paginatedResponse(pages, false, ""))
+	})
+
+	dm := &DatabaseManager{client: client}
+	cond := &Condition{
+		FilterProperties: []string{"title"},
+	}
+	pages, err := dm.Query(testContext(), "db-123", cond)
+	require.NoError(t, err)
+	assert.Empty(t, pages)
+}

--- a/notion/api_test.go
+++ b/notion/api_test.go
@@ -780,11 +780,11 @@ func TestContext_Cancellation(t *testing.T) {
 }
 
 // =============================================================================
-// Manager.WithLimiter test
+// Client.WithLimiter test
 // =============================================================================
 
-func TestManager_WithLimiter(t *testing.T) {
-	mgr := NewManager("2022-06-28", "test-token")
+func TestClient_WithLimiter(t *testing.T) {
+	mgr := NewClient("2022-06-28", "test-token")
 	newMgr := mgr.WithLimiter(defaultLimiter())
 	assert.NotNil(t, newMgr)
 	assert.NotNil(t, newMgr.client)

--- a/notion/api_test.go
+++ b/notion/api_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/time/rate"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -780,16 +782,19 @@ func TestContext_Cancellation(t *testing.T) {
 }
 
 // =============================================================================
-// Client.WithLimiter test
+// ClientOption tests
 // =============================================================================
 
-func TestClient_WithLimiter(t *testing.T) {
+func TestNewClient_WithRateLimiter(t *testing.T) {
+	custom := rate.NewLimiter(10, 20)
+	mgr := NewClient("2022-06-28", "test-token", WithRateLimiter(custom))
+	assert.NotNil(t, mgr)
+	assert.Same(t, custom, mgr.client.limiter)
+}
+
+func TestNewClient_DefaultLimiter(t *testing.T) {
 	mgr := NewClient("2022-06-28", "test-token")
-	newMgr := mgr.WithLimiter(defaultLimiter())
-	assert.NotNil(t, newMgr)
-	assert.NotNil(t, newMgr.client)
-	// Original manager should be unchanged.
-	assert.NotNil(t, mgr.client)
+	assert.NotNil(t, mgr.client.limiter)
 }
 
 // =============================================================================

--- a/notion/blocks.go
+++ b/notion/blocks.go
@@ -2,46 +2,83 @@ package notion
 
 import (
 	"context"
+	"fmt"
 
-	"golang.org/x/time/rate"
+	"github.com/tr1v3r/pkg/log"
 )
 
-// NewBlockManager return a new database manager
-func NewBlockManager(version, token string) *BlockManager {
-	return &BlockManager{baseInfo: &baseInfo{
-		NotionVersion: version,
-		BearerToken:   token,
-	}, ctx: context.Background(), limiter: rate.NewLimiter(rateLimit, 4*rateLimit)}
-}
-
-// BlockManager ...
+// BlockManager implements BlockAPI.
 type BlockManager struct {
-	*baseInfo
-
-	ctx     context.Context
-	id      string
-	limiter *rate.Limiter
+	client *notionClient
 }
 
-// WithContext set Context
-func (bm BlockManager) WithContext(ctx context.Context) *BlockManager {
-	bm.ctx = ctx
-	return &bm
+// NewBlockManager creates a BlockManager with default settings.
+func NewBlockManager(version, token string) *BlockManager {
+	return &BlockManager{
+		client: newNotionClient(version, token, defaultLimiter()),
+	}
 }
 
-// WithID set block id
-func (bm BlockManager) WithID(id string) *BlockManager {
-	bm.id = id
-	return &bm
+// Retrieve retrieves a block by ID.
+// GET /v1/blocks/{block_id}
+func (bm *BlockManager) Retrieve(ctx context.Context, id string) (*Block, error) {
+	log.CtxDebugf(ctx, "retrieve block %s", id)
+
+	var block Block
+	if err := bm.client.get(ctx, "/blocks/"+id, &block); err != nil {
+		return nil, fmt.Errorf("retrieve block %s: %w", id, err)
+	}
+	return &block, nil
 }
 
-// WithLimiter with limiiter
-func (bm BlockManager) WithLimiter(limiter *rate.Limiter) *BlockManager {
-	bm.limiter = limiter
-	return &bm
+// Update updates a block's content.
+// PATCH /v1/blocks/{block_id}
+func (bm *BlockManager) Update(ctx context.Context, id string, block *Block) (*Block, error) {
+	log.CtxDebugf(ctx, "update block %s", id)
+
+	var result Block
+	if err := bm.client.patch(ctx, "/blocks/"+id, block, &result); err != nil {
+		return nil, fmt.Errorf("update block %s: %w", id, err)
+	}
+	return &result, nil
 }
 
-// ID get block id
-func (bm *BlockManager) ID() string {
-	return bm.id
+// Delete moves a block to trash.
+// DELETE /v1/blocks/{block_id}
+func (bm *BlockManager) Delete(ctx context.Context, id string) (*Block, error) {
+	log.CtxDebugf(ctx, "delete block %s", id)
+
+	var block Block
+	if err := bm.client.delete(ctx, "/blocks/"+id, &block); err != nil {
+		return nil, fmt.Errorf("delete block %s: %w", id, err)
+	}
+	return &block, nil
+}
+
+// Children retrieves child blocks, handling pagination automatically.
+// GET /v1/blocks/{block_id}/children
+func (bm *BlockManager) Children(ctx context.Context, blockID string, opts *ListOptions) ([]Block, error) {
+	log.CtxDebugf(ctx, "retrieve block %s children", blockID)
+
+	return paginateAll[Block](ctx, bm.client, "GET", "/blocks/"+blockID+"/children", func(cursor string) any {
+		if opts == nil {
+			return &ListOptions{Cursor: cursor}
+		}
+		o := *opts
+		o.Cursor = cursor
+		return &o
+	})
+}
+
+// AppendChildren appends child blocks to a parent block.
+// POST /v1/blocks/{block_id}/children
+func (bm *BlockManager) AppendChildren(ctx context.Context, blockID string, children []Block) (*Block, error) {
+	log.CtxDebugf(ctx, "append %d children to block %s", len(children), blockID)
+
+	body := map[string]any{"children": children}
+	var block Block
+	if err := bm.client.post(ctx, "/blocks/"+blockID+"/children", body, &block); err != nil {
+		return nil, fmt.Errorf("append children to block %s: %w", blockID, err)
+	}
+	return &block, nil
 }

--- a/notion/client.go
+++ b/notion/client.go
@@ -1,0 +1,143 @@
+package notion
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/time/rate"
+
+	"github.com/tr1v3r/pkg/log"
+)
+
+// httpDoer abstracts HTTP request execution for testability.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// notionClient handles HTTP communication with the Notion API.
+type notionClient struct {
+	version string
+	token   string
+	limiter *rate.Limiter
+	http    httpDoer
+}
+
+func newNotionClient(version, token string, limiter *rate.Limiter) *notionClient {
+	return &notionClient{
+		version: version,
+		token:   token,
+		limiter: limiter,
+		http:    http.DefaultClient,
+	}
+}
+
+func (c *notionClient) headers() map[string]string {
+	return map[string]string{
+		"Notion-Version": c.version,
+		"Authorization":  "Bearer " + c.token,
+		"Content-Type":   "application/json",
+	}
+}
+
+// do performs a rate-limited HTTP request against the Notion API.
+func (c *notionClient) do(ctx context.Context, method, path string, body, result any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return fmt.Errorf("rate limiter: %w", err)
+	}
+
+	url := notionAPI() + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	for k, v := range c.headers() {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return ErrRateLimited
+	}
+
+	if resp.StatusCode >= 400 {
+		var apiErr APIError
+		if jsonErr := json.Unmarshal(respBody, &apiErr); jsonErr == nil && apiErr.Code != "" {
+			apiErr.Status = resp.StatusCode
+			return &apiErr
+		}
+		return fmt.Errorf("notion api error: [%d] %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("unmarshal response: %w", err)
+		}
+	}
+	return nil
+}
+
+// get performs a GET request.
+func (c *notionClient) get(ctx context.Context, path string, result any) error {
+	return c.do(ctx, http.MethodGet, path, nil, result)
+}
+
+// post performs a POST request.
+func (c *notionClient) post(ctx context.Context, path string, body, result any) error {
+	return c.do(ctx, http.MethodPost, path, body, result)
+}
+
+// patch performs a PATCH request.
+func (c *notionClient) patch(ctx context.Context, path string, body, result any) error {
+	return c.do(ctx, http.MethodPatch, path, body, result)
+}
+
+// delete performs a DELETE request.
+func (c *notionClient) delete(ctx context.Context, path string, result any) error {
+	return c.do(ctx, http.MethodDelete, path, nil, result)
+}
+
+// paginateAll fetches all pages of a paginated endpoint.
+func paginateAll[T any](ctx context.Context, c *notionClient, method, path string, bodyFn func(cursor string) any) ([]T, error) {
+	var all []T
+	var nextCursor string
+
+	for {
+		body := bodyFn(nextCursor)
+		var resp ListResponse[T]
+		if err := c.do(ctx, method, path, body, &resp); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Results...)
+		if !resp.HasMore {
+			break
+		}
+		nextCursor = resp.NextCursor
+		log.CtxDebugf(ctx, "paginated fetch: got %d items, fetching next page", len(all))
+	}
+	return all, nil
+}

--- a/notion/comments.go
+++ b/notion/comments.go
@@ -1,0 +1,47 @@
+package notion
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tr1v3r/pkg/log"
+)
+
+// CommentManager implements CommentAPI.
+type CommentManager struct {
+	client *notionClient
+}
+
+// NewCommentManager creates a CommentManager with default settings.
+func NewCommentManager(version, token string) *CommentManager {
+	return &CommentManager{
+		client: newNotionClient(version, token, defaultLimiter()),
+	}
+}
+
+// List retrieves comments for a block or page.
+// GET /v1/comments?block_id={block_id}
+func (cm *CommentManager) List(ctx context.Context, blockID string) ([]Comment, error) {
+	log.CtxDebugf(ctx, "list comments for block %s", blockID)
+
+	return paginateAll[Comment](ctx, cm.client, "GET", "/comments?block_id="+blockID, func(cursor string) any {
+		return &ListOptions{PageSize: 100, Cursor: cursor}
+	})
+}
+
+// Create creates a comment on a page or block.
+// POST /v1/comments
+func (cm *CommentManager) Create(ctx context.Context, parent ParentRef, text []TextObject) (*Comment, error) {
+	log.CtxDebugf(ctx, "create comment on %+v", parent)
+
+	body := map[string]any{
+		"parent":    parent,
+		"rich_text": text,
+	}
+
+	var comment Comment
+	if err := cm.client.post(ctx, "/comments", body, &comment); err != nil {
+		return nil, fmt.Errorf("create comment: %w", err)
+	}
+	return &comment, nil
+}

--- a/notion/databases.go
+++ b/notion/databases.go
@@ -1,249 +1,98 @@
 package notion
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
-	"golang.org/x/time/rate"
-
-	"github.com/tr1v3r/pkg/fetch"
-	"github.com/tr1v3r/pkg/log" //nolint:typecheck // Local package import
+	"github.com/tr1v3r/pkg/log"
 )
 
-// NewDatabaseManager return a new database manager
-func NewDatabaseManager(version, token string) *DatabaseManager {
-	return &DatabaseManager{baseInfo: &baseInfo{
-		NotionVersion: version,
-		BearerToken:   token,
-	}, ctx: context.Background(), limiter: rate.NewLimiter(rateLimit, 4*rateLimit)}
-}
-
-// DatabaseManager ...
+// DatabaseManager implements DatabaseAPI.
 type DatabaseManager struct {
-	*baseInfo
-
-	ctx     context.Context
-	id      string
-	limiter *rate.Limiter
+	client *notionClient
 }
 
-// WithContext set Context
-func (dm DatabaseManager) WithContext(ctx context.Context) *DatabaseManager {
-	dm.ctx = ctx
-	return &dm
+// NewDatabaseManager creates a DatabaseManager with default settings.
+func NewDatabaseManager(version, token string) *DatabaseManager {
+	return &DatabaseManager{
+		client: newNotionClient(version, token, defaultLimiter()),
+	}
 }
 
-// WithID set database id
-func (dm DatabaseManager) WithID(id string) *DatabaseManager {
-	dm.id = id
-	return &dm
-}
+// Create creates a database.
+// POST /v1/databases
+func (dm *DatabaseManager) Create(ctx context.Context, parent ParentRef, title []TextObject, properties map[string]*Property) (*Database, error) {
+	log.CtxDebugf(ctx, "create database")
 
-// WithLimiter with limiiter
-func (dm DatabaseManager) WithLimiter(limiter *rate.Limiter) *DatabaseManager {
-	dm.limiter = limiter
-	return &dm
-}
-
-// ID get database id
-func (dm *DatabaseManager) ID() string {
-	return dm.id
-}
-
-// Create create database
-// docs: https://developers.notion.com/reference/create-a-database
-// POST https://api.notion.com/v1/databases
-func (dm *DatabaseManager) Create(parent PageItem, title []TextObject, properties map[string]*Property) error {
-	log.CtxDebugf(dm.ctx, "create database")
-
-	payload, _ := json.Marshal(&struct {
-		Parent     PageItem             `json:"parent"`
-		Icon       *IconItem            `json:"icon,omitempty"`
-		Cover      *FileItem            `json:"cover,omitempty"`
-		Title      []TextObject         `json:"title"`
+	body := &struct {
+		Parent     ParentRef           `json:"parent"`
+		Title      []TextObject        `json:"title"`
 		Properties map[string]*Property `json:"properties"`
 	}{
 		Parent:     parent,
 		Title:      title,
 		Properties: properties,
-	})
+	}
 
-	_ = dm.limiter.Wait(dm.ctx)
-	statusCode, resp, _, err := fetch.DoRequestWithOptions("POST", dm.api(createOp),
-		append(dm.Headers(), fetch.WithContext(dm.ctx)), bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("create database fail: %w", err)
+	var db Database
+	if err := dm.client.post(ctx, "/databases", body, &db); err != nil {
+		return nil, fmt.Errorf("create database: %w", err)
 	}
-	if statusCode == 429 {
-		return ErrRateLimited
-	}
-	if statusCode != 200 {
-		return fmt.Errorf("create database fail: [%d] %s", statusCode, string(resp))
-	}
-	return nil
+	return &db, nil
 }
 
-// Retrieve retrieve database
-// docs: https://developers.notion.com/reference/retrieve-a-database
-// GET https://api.notion.com/v1/databases/{database_id}
-func (dm *DatabaseManager) Retrieve() (*Object, error) {
-	log.CtxDebugf(dm.ctx, "retrieve database %s", dm.id)
+// Retrieve retrieves a database by ID.
+// GET /v1/databases/{database_id}
+func (dm *DatabaseManager) Retrieve(ctx context.Context, id string) (*Database, error) {
+	log.CtxDebugf(ctx, "retrieve database %s", id)
 
-	_ = dm.limiter.Wait(dm.ctx)
-	resp, err := fetch.CtxGet(dm.ctx, dm.api(retrieveOp), dm.Headers()...)
-	if err != nil {
-		return nil, fmt.Errorf("retrieve database %s fail: %w", dm.id, err)
+	var db Database
+	if err := dm.client.get(ctx, "/databases/"+id, &db); err != nil {
+		return nil, fmt.Errorf("retrieve database %s: %w", id, err)
 	}
-
-	log.CtxDebugf(dm.ctx, "retrieve database got %s", string(resp))
-
-	var obj Object
-	if err := json.Unmarshal(resp, &obj); err != nil {
-		return nil, fmt.Errorf("unmarshal database %s fail: %w", dm.id, err)
-	}
-	// {"object":"error","status":401,"code":"unauthorized","message":"API token is invalid."}
-	if obj.Object == ErrorObjectType {
-		if obj.Status == 429 {
-			return nil, ErrRateLimited
-		}
-		return nil, fmt.Errorf("retrieve database fail: [%d / %s] %s", obj.Status, obj.Code, obj.Message)
-	}
-	return &obj, nil
+	return &db, nil
 }
 
-// Query query databases
-// docs: https://developers.notion.com/reference/post-database-query
-// POST https://api.notion.com/v1/databases/{database_id}/query
-func (dm *DatabaseManager) Query(cond *Condition) (objects []Object, err error) {
-	for ch, errCh := dm.asyncQuery(cond); ; {
-		select {
-		case obj, ok := <-ch:
-			if !ok {
-				return objects, nil
-			}
-			objects = append(objects, obj)
-		case err := <-errCh:
-			return nil, err
-		}
-	}
-}
-
-// AsynQuery ...
-func (dm *DatabaseManager) AsynQuery(cond *Condition) <-chan Object {
-	ch, _ := dm.asyncQuery(cond)
-	return ch
-}
-
-// asyncQuery query databases in async mode
-// docs: https://developers.notion.com/reference/post-database-query
-// POST https://api.notion.com/v1/databases/{database_id}/query
-func (dm *DatabaseManager) asyncQuery(cond *Condition) (<-chan Object, <-chan error) {
-	const defaultPageSize = 100
-
-	log.CtxDebugf(dm.ctx, "query database %s", dm.id)
+// Query queries a database with filters and sorts, returning all pages.
+// POST /v1/databases/{database_id}/query
+func (dm *DatabaseManager) Query(ctx context.Context, id string, cond *Condition) ([]Page, error) {
+	log.CtxDebugf(ctx, "query database %s", id)
 
 	if cond == nil {
-		cond = new(Condition)
+		cond = &Condition{}
 	}
 	if cond.PageSize <= 0 {
-		cond.PageSize = defaultPageSize
+		cond.PageSize = 100
 	}
 
-	ch := make(chan Object, cond.PageSize)
-	errCh := make(chan error, 1)
-
-	output := func(objs []Object) {
-		for _, obj := range objs {
-			ch <- obj
-		}
+	path := "/databases/" + id + "/query"
+	if qp := cond.QueryParams(); qp != "" {
+		path += "?" + qp
 	}
 
-	go func() {
-		// defer close(errCh)
-		defer close(ch)
-		var count int
-		var api = dm.api(queryOp) + "?" + cond.QueryParams()
-
-		var obj = new(Object)
-		for obj.HasMore = true; obj.HasMore; {
-			cond.StartCursor = obj.NextCursor
-			_ = dm.limiter.Wait(dm.ctx)
-			resp, err := fetch.CtxPost(dm.ctx, api, bytes.NewReader(cond.Payload()), dm.Headers()...)
-			if err != nil {
-				// log.CtxError(dm.ctx, "retrieve database %s fail: %s", dm.id, err)
-				errCh <- fmt.Errorf("retrieve database %s fail: %w", dm.id, err)
-				return
-			}
-
-			obj = new(Object)
-			if err := json.Unmarshal(resp, obj); err != nil {
-				errCh <- fmt.Errorf("unmarshal database %s fail: %w", dm.id, err)
-				return
-			}
-
-			// demo: {"object":"error","status":401,"code":"unauthorized","message":"API token is invalid."}
-			if obj.Object == ErrorObjectType {
-				if obj.Status == 429 {
-					errCh <- ErrRateLimited
-				} else {
-					errCh <- fmt.Errorf("query database fail: [%d / %s] %s", obj.Status, obj.Code, obj.Message)
-				}
-				return
-			}
-
-			output(obj.Results)
-			count += len(obj.Results)
-			log.CtxDebugf(dm.ctx, "total fetched %d items, next cursor: %s", count, obj.NextCursor)
-		}
-
-		log.CtxDebugf(dm.ctx, "query database got %d items", count)
-	}()
-	return ch, errCh
+	return paginateAll[Page](ctx, dm.client, "POST", path, func(cursor string) any {
+		c := *cond
+		c.StartCursor = cursor
+		return c
+	})
 }
 
-// Update update database
-// docs: https://developers.notion.com/reference/update-a-database
-// PATCH https://api.notion.com/v1/databases/{database_id}
-func (dm *DatabaseManager) Update(payload io.Reader) error {
-	log.CtxDebugf(dm.ctx, "update database %s", dm.id)
+// Update updates a database.
+// PATCH /v1/databases/{database_id}
+func (dm *DatabaseManager) Update(ctx context.Context, id string, payload io.Reader) (*Database, error) {
+	log.CtxDebugf(ctx, "update database %s", id)
 
-	_ = dm.limiter.Wait(dm.ctx)
-	resp, err := fetch.CtxPatch(dm.ctx, dm.api(updateOp), payload, dm.Headers()...)
-	if err != nil {
-		return fmt.Errorf("query api %s fail: %w", dm.id, err)
+	var raw json.RawMessage
+	if payload != nil {
+		buf, _ := io.ReadAll(payload)
+		raw = json.RawMessage(buf)
 	}
-	log.CtxDebugf(dm.ctx, "update database got %s", string(resp))
 
-	var obj Object
-	if err := json.Unmarshal(resp, &obj); err != nil {
-		return fmt.Errorf("unmarshal api response %s fail: %w", dm.id, err)
+	var db Database
+	if err := dm.client.patch(ctx, "/databases/"+id, raw, &db); err != nil {
+		return nil, fmt.Errorf("update database %s: %w", id, err)
 	}
-	// {"object":"error","status":401,"code":"unauthorized","message":"API token is invalid."}
-	if obj.Object == ErrorObjectType {
-		if obj.Status == 429 {
-			return ErrRateLimited
-		}
-		return fmt.Errorf("update fail: [%d / %s] %s", obj.Status, obj.Code, obj.Message)
-	}
-	return nil
-}
-
-// api return database api
-func (dm *DatabaseManager) api(typ operateType) string {
-	baseAPI := notionAPI() + "/databases"
-	switch typ {
-	case createOp: // POST https://api.notion.com/v1/databases
-		return baseAPI
-	case queryOp: // POST https://api.notion.com/v1/databases/{database_id}/query
-		return baseAPI + "/" + dm.id + "/query"
-	case retrieveOp: // GET https://api.notion.com/v1/databases/{database_id}
-		return baseAPI + "/" + dm.id
-	case updateOp: // PATCH https://api.notion.com/v1/databases/{database_id}
-		return baseAPI + "/" + dm.id
-	default:
-		return ""
-	}
+	return &db, nil
 }

--- a/notion/doc.go
+++ b/notion/doc.go
@@ -1,0 +1,121 @@
+// Package notion provides a Go client for the Notion API (https://developers.notion.com).
+// It offers type-safe, interface-driven access to Databases, Pages, Blocks, Users,
+// Comments, and Search endpoints with built-in rate limiting and automatic pagination.
+//
+// # Getting Started
+//
+// Create a [Manager] with your Notion API version and integration token:
+//
+//	mgr := notion.NewManager("2022-06-28", "your-notion-token")
+//
+// The [Manager] exposes six domain-specific API interfaces:
+//
+//   - [DatabaseAPI] — create, retrieve, query, and update databases
+//   - [PageAPI] — create, retrieve, update, trash pages, and retrieve page properties
+//   - [BlockAPI] — retrieve, update, delete blocks; list and append child blocks
+//   - [UserAPI] — retrieve the current bot user, list workspace users, retrieve by ID
+//   - [SearchAPI] — search pages and databases in the workspace
+//   - [CommentAPI] — list and create comments on pages and blocks
+//
+// All methods accept [context.Context] as the first argument for cancellation and timeouts.
+//
+// # Database Operations
+//
+// Query a database with filters and sorts (pagination is handled automatically):
+//
+//	pages, err := mgr.Database.Query(ctx, "database-id", &notion.Condition{
+//	    Filter: &notion.FilterCondition{
+//	        FilterSingleCondition: notion.FilterSingleCondition{
+//	            Property: "Status",
+//	            Status:   &notion.StatusFilter{Equals: "Done"},
+//	        },
+//	    },
+//	    Sorts: []notion.PropSortCondition{
+//	        {Property: "Created", Direction: "descending"},
+//	    },
+//	})
+//
+// Retrieve or create databases:
+//
+//	db, err := mgr.Database.Retrieve(ctx, "database-id")
+//	db, err := mgr.Database.Create(ctx, notion.ParentRef{PageID: "parent-page-id"}, title, properties)
+//
+// # Page Operations
+//
+// Create a page with properties:
+//
+//	page, err := mgr.Page.Create(ctx,
+//	    notion.ParentRef{DatabaseID: "db-id"},
+//	    &notion.Property{Name: "Name", Type: notion.TitleProp, Title: titleJSON},
+//	    &notion.Property{Name: "Done", Type: notion.CheckboxProp, Checkbox: ptrBool(true)},
+//	)
+//
+// Retrieve, update, or trash pages:
+//
+//	page, err := mgr.Page.Retrieve(ctx, "page-id")
+//	page, err := mgr.Page.Update(ctx, "page-id", props...)
+//	page, err := mgr.Page.Trash(ctx, "page-id")
+//
+// # Block Operations
+//
+// Retrieve blocks and their children (pagination is handled automatically):
+//
+//	block, err := mgr.Block.Retrieve(ctx, "block-id")
+//	children, err := mgr.Block.Children(ctx, "block-id", nil)
+//
+// Append child blocks:
+//
+//	block, err := mgr.Block.AppendChildren(ctx, "parent-id", []notion.Block{
+//	    {Type: "paragraph", Paragraph: &notion.RichTextBlock{
+//	        RichText: []notion.TextObject{{Text: notion.TextItem{Content: "Hello world"}}},
+//	    }},
+//	})
+//
+// # User and Comment Operations
+//
+//	me, _ := mgr.User.Me(ctx)
+//	user, _ := mgr.User.Retrieve(ctx, "user-id")
+//	users, _ := mgr.User.List(ctx)
+//
+//	comments, _ := mgr.Comment.List(ctx, "page-id")
+//	comment, _ := mgr.Comment.Create(ctx, notion.ParentRef{PageID: "page-id"}, []notion.TextObject{
+//	    {Text: notion.TextItem{Content: "Nice work!"}},
+//	})
+//
+// # Search
+//
+//	results, err := mgr.Search.Search(ctx, "keyword", &notion.SearchFilter{
+//	    Property: "object",
+//	    Value:    "page",
+//	})
+//
+// # Rate Limiting
+//
+// The client enforces the Notion API rate limit of 3 requests per second by default.
+// Customize with [Manager.WithLimiter]:
+//
+//	customMgr := mgr.WithLimiter(rate.NewLimiter(10, 20))
+//
+// # Mock Testing
+//
+// All Manager fields are interface types ([DatabaseAPI], [PageAPI], [BlockAPI],
+// [UserAPI], [SearchAPI], [CommentAPI]), enabling straightforward mock testing:
+//
+//	type mockDB struct{ notion.DatabaseAPI }
+//
+//	func (m *mockDB) Query(_ context.Context, _ string, _ *notion.Condition) ([]notion.Page, error) {
+//	    return []notion.Page{{ID: "mock-page"}}, nil
+//	}
+//
+//	testMgr := &notion.Manager{Database: &mockDB{}}
+//
+// # Error Handling
+//
+// API errors are returned as [*APIError] with Status, Code, and Message fields.
+// Rate limit responses (HTTP 429) return the [ErrRateLimited] sentinel error.
+//
+//	var apiErr *notion.APIError
+//	if errors.As(err, &apiErr) {
+//	    fmt.Println(apiErr.Status, apiErr.Code, apiErr.Message)
+//	}
+package notion

--- a/notion/doc.go
+++ b/notion/doc.go
@@ -4,11 +4,11 @@
 //
 // # Getting Started
 //
-// Create a [Manager] with your Notion API version and integration token:
+// Create a [Client] with your Notion API version and integration token:
 //
-//	mgr := notion.NewManager("2022-06-28", "your-notion-token")
+//	mgr := notion.NewClient("2022-06-28", "your-notion-token")
 //
-// The [Manager] exposes six domain-specific API interfaces:
+// The [Client] exposes six domain-specific API interfaces:
 //
 //   - [DatabaseAPI] — create, retrieve, query, and update databases
 //   - [PageAPI] — create, retrieve, update, trash pages, and retrieve page properties
@@ -92,13 +92,13 @@
 // # Rate Limiting
 //
 // The client enforces the Notion API rate limit of 3 requests per second by default.
-// Customize with [Manager.WithLimiter]:
+// Customize with [Client.WithLimiter]:
 //
 //	customMgr := mgr.WithLimiter(rate.NewLimiter(10, 20))
 //
 // # Mock Testing
 //
-// All Manager fields are interface types ([DatabaseAPI], [PageAPI], [BlockAPI],
+// All Client fields are interface types ([DatabaseAPI], [PageAPI], [BlockAPI],
 // [UserAPI], [SearchAPI], [CommentAPI]), enabling straightforward mock testing:
 //
 //	type mockDB struct{ notion.DatabaseAPI }
@@ -107,7 +107,7 @@
 //	    return []notion.Page{{ID: "mock-page"}}, nil
 //	}
 //
-//	testMgr := &notion.Manager{Database: &mockDB{}}
+//	testMgr := &notion.Client{Database: &mockDB{}}
 //
 // # Error Handling
 //

--- a/notion/doc.go
+++ b/notion/doc.go
@@ -92,9 +92,11 @@
 // # Rate Limiting
 //
 // The client enforces the Notion API rate limit of 3 requests per second by default.
-// Customize with [Client.WithLimiter]:
+// Customize with [WithRateLimiter]:
 //
-//	customMgr := mgr.WithLimiter(rate.NewLimiter(10, 20))
+//	mgr := notion.NewClient("2022-06-28", "token",
+//	    notion.WithRateLimiter(rate.NewLimiter(10, 20)),
+//	)
 //
 // # Mock Testing
 //

--- a/notion/errors.go
+++ b/notion/errors.go
@@ -1,9 +1,23 @@
 package notion
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrRateLimited rate limited
 	// https://developers.notion.com/reference/request-limits
 	ErrRateLimited = errors.New("notion rate limited")
 )
+
+// APIError represents an error response from the Notion API.
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("notion api error: [%d/%s] %s", e.Status, e.Code, e.Message)
+}

--- a/notion/filter_test.go
+++ b/notion/filter_test.go
@@ -1,0 +1,251 @@
+package notion
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCondition_QueryParams(t *testing.T) {
+	cond := &Condition{
+		FilterProperties: []string{"title", "status"},
+	}
+
+	params := cond.QueryParams()
+	assert.Contains(t, params, "filter_properties")
+	assert.Contains(t, params, "title")
+	assert.Contains(t, params, "status")
+}
+
+func TestCondition_Payload_Full(t *testing.T) {
+	cond := &Condition{
+		PageSize:    10,
+		StartCursor: "cursor-abc",
+		Filter: &FilterCondition{
+			FilterSingleCondition: FilterSingleCondition{
+				Property: "Status",
+				Status:   &StatusFilter{Equals: "Done"},
+			},
+		},
+		Sorts: []PropSortCondition{
+			{Property: "Name", Direction: "ascending"},
+		},
+	}
+
+	data := cond.Payload()
+	assert.NotNil(t, data)
+
+	var result map[string]any
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(10), result["page_size"])
+	assert.Equal(t, "cursor-abc", result["start_cursor"])
+	assert.NotNil(t, result["filter"])
+	assert.NotNil(t, result["sorts"])
+}
+
+func TestCondition_Payload_Empty(t *testing.T) {
+	cond := &Condition{}
+
+	data := cond.Payload()
+	assert.Nil(t, data)
+}
+
+func TestCondition_Payload_Nil(t *testing.T) {
+	var cond *Condition
+	data := cond.Payload()
+	assert.Nil(t, data)
+}
+
+func TestFilterCondition_SingleFilter(t *testing.T) {
+	cond := &FilterCondition{
+		FilterSingleCondition: FilterSingleCondition{
+			Property: "Priority",
+			Select:   &SelectFilter{Equals: "High"},
+		},
+	}
+
+	data, err := json.Marshal(cond)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "Priority", result["property"])
+
+	sel, ok := result["select"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "High", sel["equals"])
+}
+
+func TestFilterCondition_CompoundFilter_And(t *testing.T) {
+	cond := &FilterCondition{
+		CompoundConditions: map[string][]FilterCondition{
+			"and": {
+				{
+					FilterSingleCondition: FilterSingleCondition{
+						Property: "Done",
+						CheckBox: &CheckBoxFilter{Equals: true},
+					},
+				},
+				{
+					FilterSingleCondition: FilterSingleCondition{
+						Property: "Priority",
+						Select:   &SelectFilter{Equals: "High"},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(cond)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "and")
+
+	andFilters, ok := result["and"].([]any)
+	assert.True(t, ok)
+	assert.Len(t, andFilters, 2)
+}
+
+func TestFilterCondition_CompoundFilter_Or(t *testing.T) {
+	cond := &FilterCondition{
+		CompoundConditions: map[string][]FilterCondition{
+			"or": {
+				{
+					FilterSingleCondition: FilterSingleCondition{
+						Property: "Tags",
+						Select:   &SelectFilter{Equals: "Go"},
+					},
+				},
+				{
+					FilterSingleCondition: FilterSingleCondition{
+						Property: "Tags",
+						Select:   &SelectFilter{Equals: "Python"},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(cond)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "or")
+
+	orFilters, ok := result["or"].([]any)
+	assert.True(t, ok)
+	assert.Len(t, orFilters, 2)
+}
+
+func TestSelectFilter(t *testing.T) {
+	equals := &SelectFilter{Equals: "Active"}
+	data, err := json.Marshal(equals)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "Active", result["equals"])
+
+	doesNotEqual := &SelectFilter{DoesNotEqual: "Archived"}
+	data, err = json.Marshal(doesNotEqual)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "Archived", result["does_not_equal"])
+}
+
+func TestDateFilter(t *testing.T) {
+	before := &DateFilter{Before: "2024-12-31"}
+	data, err := json.Marshal(before)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "2024-12-31", result["before"])
+
+	after := &DateFilter{After: "2024-01-01"}
+	data, err = json.Marshal(after)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "2024-01-01", result["after"])
+}
+
+func TestRichTextFilter(t *testing.T) {
+	contains := &RichTextFilter{Contains: "hello"}
+	data, err := json.Marshal(contains)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", result["contains"])
+
+	equals := &RichTextFilter{Equals: "exact match"}
+	data, err = json.Marshal(equals)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "exact match", result["equals"])
+}
+
+func TestNumberFilter(t *testing.T) {
+	val := 100.0
+	greaterThan := &NumberFilter{GreaterThan: &val}
+	data, err := json.Marshal(greaterThan)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, val, result["greater_than"])
+
+	equalsVal := 42.0
+	equals := &NumberFilter{Equals: &equalsVal}
+	data, err = json.Marshal(equals)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, equalsVal, result["equals"])
+}
+
+func TestStatusFilter(t *testing.T) {
+	status := &StatusFilter{Equals: "In Progress"}
+	data, err := json.Marshal(status)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "In Progress", result["equals"])
+}
+
+func TestPropSortCondition(t *testing.T) {
+	sort := PropSortCondition{
+		Property:  "Created Time",
+		Direction: "descending",
+	}
+
+	data, err := json.Marshal(sort)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "Created Time", result["property"])
+	assert.Equal(t, "descending", result["direction"])
+}

--- a/notion/interfaces.go
+++ b/notion/interfaces.go
@@ -1,0 +1,56 @@
+package notion
+
+import (
+	"context"
+	"io"
+)
+
+// DatabaseAPI defines database operations against the Notion API.
+type DatabaseAPI interface {
+	Create(ctx context.Context, parent ParentRef, title []TextObject, properties map[string]*Property) (*Database, error)
+	Retrieve(ctx context.Context, id string) (*Database, error)
+	Query(ctx context.Context, id string, cond *Condition) ([]Page, error)
+	Update(ctx context.Context, id string, payload io.Reader) (*Database, error)
+}
+
+// PageAPI defines page operations against the Notion API.
+type PageAPI interface {
+	Create(ctx context.Context, parent ParentRef, properties ...*Property) (*Page, error)
+	Retrieve(ctx context.Context, id string) (*Page, error)
+	Update(ctx context.Context, id string, properties ...*Property) (*Page, error)
+	Trash(ctx context.Context, id string) (*Page, error)
+	RetrieveProperty(ctx context.Context, pageID, propertyID string) (*Property, error)
+}
+
+// BlockAPI defines block operations against the Notion API.
+type BlockAPI interface {
+	Retrieve(ctx context.Context, id string) (*Block, error)
+	Update(ctx context.Context, id string, block *Block) (*Block, error)
+	Delete(ctx context.Context, id string) (*Block, error)
+	Children(ctx context.Context, blockID string, opts *ListOptions) ([]Block, error)
+	AppendChildren(ctx context.Context, blockID string, children []Block) (*Block, error)
+}
+
+// UserAPI defines user operations against the Notion API.
+type UserAPI interface {
+	Me(ctx context.Context) (*User, error)
+	Retrieve(ctx context.Context, id string) (*User, error)
+	List(ctx context.Context) ([]User, error)
+}
+
+// SearchAPI defines search operations against the Notion API.
+type SearchAPI interface {
+	Search(ctx context.Context, query string, filter *SearchFilter) (*ListResponse[SearchResult], error)
+}
+
+// CommentAPI defines comment operations against the Notion API.
+type CommentAPI interface {
+	List(ctx context.Context, blockID string) ([]Comment, error)
+	Create(ctx context.Context, parent ParentRef, text []TextObject) (*Comment, error)
+}
+
+// ListOptions controls pagination for list endpoints.
+type ListOptions struct {
+	PageSize int    `json:"page_size,omitempty"`
+	Cursor   string `json:"start_cursor,omitempty"`
+}

--- a/notion/manager.go
+++ b/notion/manager.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"golang.org/x/time/rate"
-
-	"github.com/tr1v3r/pkg/fetch"
 )
 
 const (
@@ -15,88 +13,64 @@ const (
 	apiBasePath         = "v1"
 )
 
-// operateType define operate type
-type operateType string
-
-const (
-	createOp       operateType = "create"
-	queryOp        operateType = "query"
-	retrieveOp     operateType = "retrieve"
-	retrievePropOp operateType = "retrieveProp"
-	updateOp       operateType = "update"
-)
-
-// notionAPI return notion api url
 func notionAPI() string {
 	return fmt.Sprintf("%s://%s/%s", notionAPIHostScheme, notionAPIHost, apiBasePath)
 }
 
-// Manager is a manager for notion
+func defaultLimiter() *rate.Limiter {
+	return rate.NewLimiter(rateLimit, 4*rateLimit)
+}
+
+// Manager is the top-level facade for the Notion API.
 type Manager struct {
-	*DatabaseManager
-	*PageManager
-	*BlockManager
-	*SearchManager
+	Database DatabaseAPI
+	Page     PageAPI
+	Block    BlockAPI
+	Search   SearchAPI
+	User     UserAPI
+	Comment  CommentAPI
 
-	*baseInfo
+	client *notionClient
 }
 
-// NewManager return a new notion manager
+// NewManager creates a Manager with the given Notion API version and token.
 func NewManager(version, token string) *Manager {
-	limiter := rate.NewLimiter(rateLimit, 4*rateLimit)
+	limiter := defaultLimiter()
+	client := newNotionClient(version, token, limiter)
+
 	return &Manager{
-		DatabaseManager: NewDatabaseManager(version, token).WithLimiter(limiter),
-		PageManager:     NewPageManager(version, token).WithLimiter(limiter),
-		BlockManager:    NewBlockManager(version, token).WithLimiter(limiter),
-		SearchManager:   NewSearchManager(version, token).WithLimiter(limiter),
-		baseInfo: &baseInfo{
-			NotionVersion: version,
-			BearerToken:   token,
-		},
+		Database: &DatabaseManager{client: client},
+		Page:     &PageManager{client: client},
+		Block:    &BlockManager{client: client},
+		Search:   &SearchManager{client: client},
+		User:     &UserManager{client: client},
+		Comment:  &CommentManager{client: client},
+		client:   client,
 	}
 }
 
-// Set set notion version and token
+// Set updates the Notion API version and token.
 func (mgr *Manager) Set(version, token string) {
-	mgr.DatabaseManager.Set(version, token)
-	mgr.PageManager.Set(version, token)
-	mgr.BlockManager.Set(version, token)
-	mgr.SearchManager.Set(version, token)
-	mgr.baseInfo.Set(version, token)
+	mgr.client.version = version
+	mgr.client.token = token
 }
 
-// WithContext set context for notion manager
+// WithContext returns a new Manager with the given context.
 func (mgr Manager) WithContext(ctx context.Context) *Manager {
-	mgr.DatabaseManager = mgr.DatabaseManager.WithContext(ctx)
-	mgr.PageManager = mgr.PageManager.WithContext(ctx)
-	mgr.BlockManager = mgr.BlockManager.WithContext(ctx)
-	mgr.SearchManager = mgr.SearchManager.WithContext(ctx)
-	return &mgr
-}
-
-// WithLimiter set limiter for notion manager
-func (mgr Manager) WithLimiter(limiter *rate.Limiter) *Manager {
-	mgr.DatabaseManager = mgr.DatabaseManager.WithLimiter(limiter)
-	mgr.PageManager = mgr.PageManager.WithLimiter(limiter)
-	mgr.BlockManager = mgr.BlockManager.WithLimiter(limiter)
-	mgr.SearchManager = mgr.SearchManager.WithLimiter(limiter)
-	return &mgr
-}
-
-type baseInfo struct {
-	NotionVersion string
-	BearerToken   string
-}
-
-func (i *baseInfo) Headers() []fetch.RequestOption {
-	return []fetch.RequestOption{
-		fetch.WithHeader("Notion-Version", i.NotionVersion),
-		fetch.WithAuthToken("Bearer " + i.BearerToken),
-		fetch.WithContentTypeJSON(),
+	mgr.client = &notionClient{
+		version: mgr.client.version,
+		token:   mgr.client.token,
+		limiter: mgr.client.limiter,
 	}
+	return &mgr
 }
 
-func (i *baseInfo) Set(version, token string) {
-	i.NotionVersion = version
-	i.BearerToken = token
+// WithLimiter returns a new Manager with the given rate limiter.
+func (mgr Manager) WithLimiter(limiter *rate.Limiter) *Manager {
+	mgr.client = &notionClient{
+		version: mgr.client.version,
+		token:   mgr.client.token,
+		limiter: limiter,
+	}
+	return &mgr
 }

--- a/notion/manager.go
+++ b/notion/manager.go
@@ -21,8 +21,8 @@ func defaultLimiter() *rate.Limiter {
 	return rate.NewLimiter(rateLimit, 4*rateLimit)
 }
 
-// Manager is the top-level facade for the Notion API.
-type Manager struct {
+// Client is the top-level facade for the Notion API.
+type Client struct {
 	Database DatabaseAPI
 	Page     PageAPI
 	Block    BlockAPI
@@ -33,12 +33,12 @@ type Manager struct {
 	client *notionClient
 }
 
-// NewManager creates a Manager with the given Notion API version and token.
-func NewManager(version, token string) *Manager {
+// NewClient creates a Client with the given Notion API version and token.
+func NewClient(version, token string) *Client {
 	limiter := defaultLimiter()
 	client := newNotionClient(version, token, limiter)
 
-	return &Manager{
+	return &Client{
 		Database: &DatabaseManager{client: client},
 		Page:     &PageManager{client: client},
 		Block:    &BlockManager{client: client},
@@ -50,27 +50,27 @@ func NewManager(version, token string) *Manager {
 }
 
 // Set updates the Notion API version and token.
-func (mgr *Manager) Set(version, token string) {
-	mgr.client.version = version
-	mgr.client.token = token
+func (c *Client) Set(version, token string) {
+	c.client.version = version
+	c.client.token = token
 }
 
-// WithContext returns a new Manager with the given context.
-func (mgr Manager) WithContext(ctx context.Context) *Manager {
-	mgr.client = &notionClient{
-		version: mgr.client.version,
-		token:   mgr.client.token,
-		limiter: mgr.client.limiter,
+// WithContext returns a new Client with the given context.
+func (c Client) WithContext(ctx context.Context) *Client {
+	c.client = &notionClient{
+		version: c.client.version,
+		token:   c.client.token,
+		limiter: c.client.limiter,
 	}
-	return &mgr
+	return &c
 }
 
-// WithLimiter returns a new Manager with the given rate limiter.
-func (mgr Manager) WithLimiter(limiter *rate.Limiter) *Manager {
-	mgr.client = &notionClient{
-		version: mgr.client.version,
-		token:   mgr.client.token,
+// WithLimiter returns a new Client with the given rate limiter.
+func (c Client) WithLimiter(limiter *rate.Limiter) *Client {
+	c.client = &notionClient{
+		version: c.client.version,
+		token:   c.client.token,
 		limiter: limiter,
 	}
-	return &mgr
+	return &c
 }

--- a/notion/manager.go
+++ b/notion/manager.go
@@ -1,7 +1,6 @@
 package notion
 
 import (
-	"context"
 	"fmt"
 
 	"golang.org/x/time/rate"
@@ -21,6 +20,14 @@ func defaultLimiter() *rate.Limiter {
 	return rate.NewLimiter(rateLimit, 4*rateLimit)
 }
 
+// ClientOption configures a [Client].
+type ClientOption func(*Client)
+
+// WithRateLimiter sets a custom rate limiter. Defaults to 3 requests/second with burst of 12.
+func WithRateLimiter(limiter *rate.Limiter) ClientOption {
+	return func(c *Client) { c.client.limiter = limiter }
+}
+
 // Client is the top-level facade for the Notion API.
 type Client struct {
 	Database DatabaseAPI
@@ -34,43 +41,27 @@ type Client struct {
 }
 
 // NewClient creates a Client with the given Notion API version and token.
-func NewClient(version, token string) *Client {
-	limiter := defaultLimiter()
-	client := newNotionClient(version, token, limiter)
+func NewClient(version, token string, opts ...ClientOption) *Client {
+	nc := newNotionClient(version, token, defaultLimiter())
 
-	return &Client{
-		Database: &DatabaseManager{client: client},
-		Page:     &PageManager{client: client},
-		Block:    &BlockManager{client: client},
-		Search:   &SearchManager{client: client},
-		User:     &UserManager{client: client},
-		Comment:  &CommentManager{client: client},
-		client:   client,
+	c := &Client{
+		Database: &DatabaseManager{client: nc},
+		Page:     &PageManager{client: nc},
+		Block:    &BlockManager{client: nc},
+		Search:   &SearchManager{client: nc},
+		User:     &UserManager{client: nc},
+		Comment:  &CommentManager{client: nc},
+		client:   nc,
 	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // Set updates the Notion API version and token.
 func (c *Client) Set(version, token string) {
 	c.client.version = version
 	c.client.token = token
-}
-
-// WithContext returns a new Client with the given context.
-func (c Client) WithContext(ctx context.Context) *Client {
-	c.client = &notionClient{
-		version: c.client.version,
-		token:   c.client.token,
-		limiter: c.client.limiter,
-	}
-	return &c
-}
-
-// WithLimiter returns a new Client with the given rate limiter.
-func (c Client) WithLimiter(limiter *rate.Limiter) *Client {
-	c.client = &notionClient{
-		version: c.client.version,
-		token:   c.client.token,
-		limiter: limiter,
-	}
-	return &c
 }

--- a/notion/manager_unit_test.go
+++ b/notion/manager_unit_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewManager(t *testing.T) {
+func TestNewClient(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
 
-	mgr := NewManager(version, token)
+	mgr := NewClient(version, token)
 
 	assert.NotNil(t, mgr)
 	assert.NotNil(t, mgr.Database)
@@ -25,7 +25,7 @@ func TestManagerClient(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
 
-	mgr := NewManager(version, token)
+	mgr := NewClient(version, token)
 
 	assert.NotNil(t, mgr.client)
 	assert.Equal(t, version, mgr.client.version)
@@ -39,7 +39,7 @@ func TestManagerSet(t *testing.T) {
 	version2 := "2022-10-01"
 	token2 := "test-token-2"
 
-	mgr := NewManager(version1, token1)
+	mgr := NewClient(version1, token1)
 	assert.Equal(t, version1, mgr.client.version)
 	assert.Equal(t, token1, mgr.client.token)
 

--- a/notion/manager_unit_test.go
+++ b/notion/manager_unit_test.go
@@ -13,70 +13,24 @@ func TestNewManager(t *testing.T) {
 	mgr := NewManager(version, token)
 
 	assert.NotNil(t, mgr)
-	assert.NotNil(t, mgr.DatabaseManager)
-	assert.NotNil(t, mgr.PageManager)
-	assert.NotNil(t, mgr.BlockManager)
-	assert.NotNil(t, mgr.SearchManager)
+	assert.NotNil(t, mgr.Database)
+	assert.NotNil(t, mgr.Page)
+	assert.NotNil(t, mgr.Block)
+	assert.NotNil(t, mgr.Search)
+	assert.NotNil(t, mgr.User)
+	assert.NotNil(t, mgr.Comment)
 }
 
-func TestManagerHeaders(t *testing.T) {
+func TestManagerClient(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
 
 	mgr := NewManager(version, token)
-	headers := mgr.Headers()
 
-	// Headers returns []fetch.RequestOption, so we just verify it's not empty
-	assert.NotEmpty(t, headers)
-	assert.Len(t, headers, 3) // Should have 3 headers: Notion-Version, Authorization, Content-Type
-}
-
-func TestDatabaseManagerCreation(t *testing.T) {
-	version := "2022-06-28"
-	token := "test-token"
-
-	dbMgr := NewDatabaseManager(version, token)
-
-	assert.NotNil(t, dbMgr)
-	assert.NotNil(t, dbMgr.baseInfo)
-	assert.Equal(t, version, dbMgr.baseInfo.NotionVersion)
-	assert.Equal(t, token, dbMgr.baseInfo.BearerToken)
-}
-
-func TestPageManagerCreation(t *testing.T) {
-	version := "2022-06-28"
-	token := "test-token"
-
-	pageMgr := NewPageManager(version, token)
-
-	assert.NotNil(t, pageMgr)
-	assert.NotNil(t, pageMgr.baseInfo)
-	assert.Equal(t, version, pageMgr.baseInfo.NotionVersion)
-	assert.Equal(t, token, pageMgr.baseInfo.BearerToken)
-}
-
-func TestBlockManagerCreation(t *testing.T) {
-	version := "2022-06-28"
-	token := "test-token"
-
-	blockMgr := NewBlockManager(version, token)
-
-	assert.NotNil(t, blockMgr)
-	assert.NotNil(t, blockMgr.baseInfo)
-	assert.Equal(t, version, blockMgr.baseInfo.NotionVersion)
-	assert.Equal(t, token, blockMgr.baseInfo.BearerToken)
-}
-
-func TestSearchManagerCreation(t *testing.T) {
-	version := "2022-06-28"
-	token := "test-token"
-
-	searchMgr := NewSearchManager(version, token)
-
-	assert.NotNil(t, searchMgr)
-	assert.NotNil(t, searchMgr.baseInfo)
-	assert.Equal(t, version, searchMgr.baseInfo.NotionVersion)
-	assert.Equal(t, token, searchMgr.baseInfo.BearerToken)
+	assert.NotNil(t, mgr.client)
+	assert.Equal(t, version, mgr.client.version)
+	assert.Equal(t, token, mgr.client.token)
+	assert.NotNil(t, mgr.client.limiter)
 }
 
 func TestManagerSet(t *testing.T) {
@@ -86,77 +40,88 @@ func TestManagerSet(t *testing.T) {
 	token2 := "test-token-2"
 
 	mgr := NewManager(version1, token1)
-	assert.Equal(t, version1, mgr.baseInfo.NotionVersion)
-	assert.Equal(t, token1, mgr.baseInfo.BearerToken)
+	assert.Equal(t, version1, mgr.client.version)
+	assert.Equal(t, token1, mgr.client.token)
 
 	mgr.Set(version2, token2)
-	assert.Equal(t, version2, mgr.baseInfo.NotionVersion)
-	assert.Equal(t, token2, mgr.baseInfo.BearerToken)
+	assert.Equal(t, version2, mgr.client.version)
+	assert.Equal(t, token2, mgr.client.token)
 }
 
-func TestDatabaseManagerWithID(t *testing.T) {
+func TestDatabaseManagerCreation(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
-	databaseID := "test-database-id"
 
-	mgr := NewManager(version, token)
-	dbMgr := mgr.DatabaseManager.WithID(databaseID)
+	dbMgr := NewDatabaseManager(version, token)
 
 	assert.NotNil(t, dbMgr)
-	// The WithID method should return a new manager with updated ID
-	assert.NotEqual(t, mgr.DatabaseManager, dbMgr) // Different instances
-	// Verify the new manager has the updated baseInfo (they share baseInfo)
-	assert.Equal(t, mgr.DatabaseManager.baseInfo, dbMgr.baseInfo)
+	assert.NotNil(t, dbMgr.client)
+	assert.Equal(t, version, dbMgr.client.version)
+	assert.Equal(t, token, dbMgr.client.token)
 }
 
-func TestPageManagerWithID(t *testing.T) {
+func TestPageManagerCreation(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
-	pageID := "test-page-id"
 
-	mgr := NewManager(version, token)
-	pageMgr := mgr.PageManager.WithID(pageID)
+	pageMgr := NewPageManager(version, token)
 
 	assert.NotNil(t, pageMgr)
-	// The WithID method should return a new manager
-	assert.NotEqual(t, mgr.PageManager, pageMgr)
+	assert.NotNil(t, pageMgr.client)
+	assert.Equal(t, version, pageMgr.client.version)
+	assert.Equal(t, token, pageMgr.client.token)
 }
 
-func TestBlockManagerWithID(t *testing.T) {
+func TestBlockManagerCreation(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
-	blockID := "test-block-id"
 
-	mgr := NewManager(version, token)
-	blockMgr := mgr.BlockManager.WithID(blockID)
+	blockMgr := NewBlockManager(version, token)
 
 	assert.NotNil(t, blockMgr)
-	// The WithID method should return a new manager
-	assert.NotEqual(t, mgr.BlockManager, blockMgr)
+	assert.NotNil(t, blockMgr.client)
+	assert.Equal(t, version, blockMgr.client.version)
+	assert.Equal(t, token, blockMgr.client.token)
 }
 
-func TestSearchManagerWithLimiter(t *testing.T) {
+func TestSearchManagerCreation(t *testing.T) {
 	version := "2022-06-28"
 	token := "test-token"
 
-	mgr := NewManager(version, token)
-	searchMgr := mgr.SearchManager.WithLimiter(nil) // Can pass nil for test
+	searchMgr := NewSearchManager(version, token)
 
 	assert.NotNil(t, searchMgr)
-	// The WithLimiter method should return a new manager
-	assert.NotEqual(t, mgr.SearchManager, searchMgr)
+	assert.NotNil(t, searchMgr.client)
+	assert.Equal(t, version, searchMgr.client.version)
+	assert.Equal(t, token, searchMgr.client.token)
+}
+
+func TestUserManagerCreation(t *testing.T) {
+	version := "2022-06-28"
+	token := "test-token"
+
+	userMgr := NewUserManager(version, token)
+
+	assert.NotNil(t, userMgr)
+	assert.NotNil(t, userMgr.client)
+}
+
+func TestCommentManagerCreation(t *testing.T) {
+	version := "2022-06-28"
+	token := "test-token"
+
+	commentMgr := NewCommentManager(version, token)
+
+	assert.NotNil(t, commentMgr)
+	assert.NotNil(t, commentMgr.client)
 }
 
 func TestNotionAPIConstants(t *testing.T) {
-	// Test the constant we defined for lint fixes
 	assert.Equal(t, "error", ErrorObjectType)
-
-	// Test rate limit constant from object.go
 	assert.Equal(t, 3, rateLimit)
 }
 
 func TestNotionAPIHost(t *testing.T) {
-	// Test the API host generation
 	expected := "https://api.notion.com/v1"
 	actual := notionAPI()
 	assert.Equal(t, expected, actual)

--- a/notion/mock_test.go
+++ b/notion/mock_test.go
@@ -1,0 +1,213 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/time/rate"
+)
+
+// mockServer creates an httptest.Server that delegates to handler and returns
+// the server (for cleanup) and a notionClient wired to use it.
+func mockServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *notionClient) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Transport: http.DefaultTransport,
+	}
+	// Override the notionAPI base URL via a client wrapper that rewrites URLs.
+	nc := &notionClient{
+		version: "2022-06-28",
+		token:   "test-token",
+		limiter: rate.NewLimiter(1000, 1000),
+		http:    urlRewriteClient{base: srv.URL, inner: client},
+	}
+	return srv, nc
+}
+
+// urlRewriteClient is an httpDoer that rewrites request URLs to point at a
+// test server while preserving the path and query string.
+type urlRewriteClient struct {
+	base  string
+	inner *http.Client
+}
+
+func (r urlRewriteClient) Do(req *http.Request) (*http.Response, error) {
+	// Replace scheme+host with test server, keep path+query.
+	baseURL, err := parseBaseURL(r.base)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.Host = baseURL.Host
+	req.URL.Scheme = baseURL.Scheme
+	req.Host = baseURL.Host
+	return r.inner.Do(req)
+}
+
+// baseURL holds parsed scheme and host from the test server URL.
+type baseURL struct {
+	Scheme string
+	Host   string
+}
+
+func parseBaseURL(raw string) (baseURL, error) {
+	// Simple parse: expect "http://host:port".
+	for _, scheme := range []string{"http://", "https://"} {
+		if len(raw) > len(scheme) && raw[:len(scheme)] == scheme {
+			return baseURL{Scheme: scheme[:len(scheme)-3], Host: raw[len(scheme):]}, nil
+		}
+	}
+	return baseURL{}, fmt.Errorf("invalid base URL: %s", raw)
+}
+
+// testContext returns a background context for tests.
+func testContext() context.Context {
+	return context.Background()
+}
+
+// --- Response helpers ---
+
+// jsonRespond writes a JSON response with the given status code.
+func jsonRespond(w http.ResponseWriter, statusCode int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	data, _ := json.Marshal(v)
+	w.Write(data) //nolint:errcheck
+}
+
+// errorRespond writes a Notion-style API error response.
+func errorRespond(w http.ResponseWriter, statusCode int, code, message string) {
+	jsonRespond(w, statusCode, map[string]any{
+		"object":  "error",
+		"status":  statusCode,
+		"code":    code,
+		"message": message,
+	})
+}
+
+// readBody reads and returns the request body as a map for assertion.
+func readBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	return m
+}
+
+// verifyAuth checks that required Notion headers are present.
+func verifyAuth(t *testing.T, r *http.Request) {
+	t.Helper()
+	if v := r.Header.Get("Notion-Version"); v != "2022-06-28" {
+		t.Errorf("expected Notion-Version header '2022-06-28', got %q", v)
+	}
+	if v := r.Header.Get("Authorization"); v != "Bearer test-token" {
+		t.Errorf("expected Authorization header 'Bearer test-token', got %q", v)
+	}
+	if v := r.Header.Get("Content-Type"); v != "application/json" {
+		t.Errorf("expected Content-Type header 'application/json', got %q", v)
+	}
+}
+
+// --- Fixture data helpers -----
+
+// sampleDatabaseJSON returns a JSON-encoded Notion database response.
+func sampleDatabaseJSON() string {
+	return `{
+		"object": "database",
+		"id": "db-123",
+		"created_time": "2024-01-01T00:00:00Z",
+		"created_by": {"object": "user", "id": "user-1"},
+		"last_edited_time": "2024-01-02T00:00:00Z",
+		"last_edited_by": {"object": "user", "id": "user-2"},
+		"title": [{"type": "text", "text": {"content": "Test DB"}, "plain_text": "Test DB"}],
+		"url": "https://notion.so/db-123",
+		"properties": {
+			"Name": {"id": "prop-1", "name": "Name", "type": "title", "title": []}
+		}
+	}`
+}
+
+// samplePageJSON returns a JSON-encoded Notion page response.
+func samplePageJSON() string {
+	return `{
+		"object": "page",
+		"id": "page-123",
+		"created_time": "2024-01-01T00:00:00Z",
+		"created_by": {"object": "user", "id": "user-1"},
+		"last_edited_time": "2024-01-02T00:00:00Z",
+		"last_edited_by": {"object": "user", "id": "user-2"},
+		"parent": {"type": "database_id", "database_id": "db-123"},
+		"url": "https://notion.so/page-123",
+		"archived": false,
+		"in_trash": false,
+		"properties": {
+			"Name": {"id": "prop-1", "name": "Name", "type": "title", "title": [{"type": "text", "text": {"content": "Hello"}, "plain_text": "Hello"}]}
+		}
+	}`
+}
+
+// sampleBlockJSON returns a JSON-encoded Notion block response.
+func sampleBlockJSON() string {
+	return `{
+		"object": "block",
+		"id": "block-123",
+		"parent": {"type": "page_id", "page_id": "page-123"},
+		"type": "paragraph",
+		"created_time": "2024-01-01T00:00:00Z",
+		"created_by": {"object": "user", "id": "user-1"},
+		"last_edited_time": "2024-01-02T00:00:00Z",
+		"last_edited_by": {"object": "user", "id": "user-2"},
+		"has_children": false,
+		"paragraph": {"rich_text": [{"type": "text", "text": {"content": "Hello world"}, "plain_text": "Hello world"}]}
+	}`
+}
+
+// sampleUserJSON returns a JSON-encoded Notion user response.
+func sampleUserJSON() string {
+	return `{
+		"object": "user",
+		"id": "user-123",
+		"type": "person",
+		"name": "Test User",
+		"avatar_url": "https://example.com/avatar.png"
+	}`
+}
+
+// sampleCommentJSON returns a JSON-encoded Notion comment response.
+func sampleCommentJSON() string {
+	return `{
+		"object": "comment",
+		"id": "comment-123",
+		"parent": {"type": "page_id", "page_id": "page-123"},
+		"discussion_id": "disc-123",
+		"created_time": "2024-01-01T00:00:00Z",
+		"last_edited_time": "2024-01-01T00:00:00Z",
+		"created_by": {"object": "user", "id": "user-1"},
+		"rich_text": [{"type": "text", "text": {"content": "Nice work!"}, "plain_text": "Nice work!"}]
+	}`
+}
+
+// paginatedResponse wraps results in a paginated response envelope.
+func paginatedResponse(results any, hasMore bool, nextCursor string) map[string]any {
+	return map[string]any{
+		"object":     "list",
+		"results":    results,
+		"has_more":   hasMore,
+		"next_cursor": nextCursor,
+	}
+}

--- a/notion/notion_test.go
+++ b/notion/notion_test.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func TestRetrieve_Database(t *testing.T) {
-	mgr := NewManager(version, token)
+	mgr := NewClient(version, token)
 	db, err := mgr.Database.Retrieve(context.Background(), databaseID)
 	if err != nil {
 		t.Fatalf("retrieve fail: %s", err)
@@ -31,7 +31,7 @@ func TestRetrieve_Database(t *testing.T) {
 }
 
 func TestQuery_Database_all(t *testing.T) {
-	mgr := NewManager(version, token)
+	mgr := NewClient(version, token)
 
 	results, err := mgr.Database.Query(context.Background(), databaseID, &Condition{
 		Sorts: []PropSortCondition{{Property: "总市值", Direction: "descending"}},
@@ -46,7 +46,7 @@ func TestQuery_Database_all(t *testing.T) {
 }
 
 func TestCreate_Page(t *testing.T) {
-	mgr := NewManager(version, token)
+	mgr := NewClient(version, token)
 
 	data, _ := json.Marshal([]TextObject{{
 		Text:        TextItem{Content: "000001"},

--- a/notion/notion_test.go
+++ b/notion/notion_test.go
@@ -1,6 +1,7 @@
 package notion
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -9,8 +10,9 @@ import (
 )
 
 var (
-	version = os.Getenv("NOTION_VERSION")
-	token   = os.Getenv("NOTION_TOKEN")
+	version    = os.Getenv("NOTION_VERSION")
+	token      = os.Getenv("NOTION_TOKEN")
+	databaseID = os.Getenv("NOTION_DATABASE_ID")
 )
 
 func init() {
@@ -19,52 +21,43 @@ func init() {
 
 func TestRetrieve_Database(t *testing.T) {
 	mgr := NewManager(version, token)
-	mgr.DatabaseManager.id = os.Getenv("NOTION_DATABASE_ID")
-	obj, err := mgr.DatabaseManager.Retrieve()
+	db, err := mgr.Database.Retrieve(context.Background(), databaseID)
 	if err != nil {
-		t.Errorf("query fail: %s", err)
-		return
+		t.Fatalf("retrieve fail: %s", err)
 	}
 
-	data, _ := json.Marshal(obj)
+	data, _ := json.Marshal(db)
 	t.Logf("retrieve database success: %s", string(data))
 }
 
 func TestQuery_Database_all(t *testing.T) {
 	mgr := NewManager(version, token)
-	mgr.DatabaseManager.WithID(os.Getenv("NOTION_DATABASE_ID"))
 
-	// query all
-	//nolint:staticcheck // Using embedded field is intentional for manager pattern
-	results, err := mgr.DatabaseManager.Query(&Condition{
+	results, err := mgr.Database.Query(context.Background(), databaseID, &Condition{
 		Sorts: []PropSortCondition{{Property: "总市值", Direction: "descending"}},
 	})
 	if err != nil {
-		t.Errorf("query fail: %s", err)
-		return
+		t.Fatalf("query fail: %s", err)
 	}
 	t.Logf("got %d results", len(results))
 	for _, result := range results {
 		t.Logf("got %v\n", result.Properties["Name"])
 	}
-
-	// data, _ := json.Marshal(obj)
-	// t.Logf("query database all items success: %s", string(data))
 }
 
 func TestCreate_Page(t *testing.T) {
-	databaseID := os.Getenv("NOTION_DATABASE_ID")
-
 	mgr := NewManager(version, token)
 
 	data, _ := json.Marshal([]TextObject{{
 		Text:        TextItem{Content: "000001"},
 		Annotations: &Annotation{Bold: true, Color: "default"},
 	}})
-	err := mgr.PageManager.Create(PageItem{DatabaseID: databaseID},
+	page, err := mgr.Page.Create(context.Background(),
+		PageItem{DatabaseID: databaseID},
 		&Property{Name: "Code", Type: RichTextProp, RichText: data},
 	)
 	if err != nil {
-		t.Errorf("create page fail: %s", err)
+		t.Fatalf("create page fail: %s", err)
 	}
+	t.Logf("created page: %s", page.ID)
 }

--- a/notion/object.go
+++ b/notion/object.go
@@ -19,13 +19,13 @@ type Object struct {
 	CreatedBy      PureObject          `json:"created_by"`
 	LastEditedTime string              `json:"last_edited_time"`
 	LastEditedBy   PureObject          `json:"last_edited_by"`
-	Cover          FileItem            `json:"cover,omitempty"`
-	Icon           IconItem            `json:"icon,omitempty"`
+	Cover          FileItem            `json:"cover"`
+	Icon           IconItem            `json:"icon"`
 	Title          []TextItem          `json:"title,omitempty"`
 	Description    []TextItem          `json:"description,omitempty"`
 	IsInline       bool                `json:"is_inline,omitempty"`
 	Properties     map[string]Property `json:"properties,omitempty"`
-	Parent         PageItem            `json:"parent,omitempty"`
+	Parent         PageItem            `json:"parent"`
 	URL            string              `json:"url,omitempty"`
 	Archived       bool                `json:"archived,omitempty"`
 	Results        []Object            `json:"results,omitempty"`
@@ -33,10 +33,10 @@ type Object struct {
 	HasMore        bool                `json:"has_more"`
 	Type           string              `json:"type"`
 	RequestID      string              `json:"request_id,omitempty"`
-	PropertyItem   Property            `json:"property,omitempty"`
+	PropertyItem   Property            `json:"property"`
 
-	Relation RelationItem `json:"relation,omitempty"`
-	RichText TextObject   `json:"rich_text,omitempty"`
+	Relation RelationItem `json:"relation"`
+	RichText TextObject   `json:"rich_text"`
 
 	Status  int    `json:"status,omitempty"`
 	Code    string `json:"code,omitempty"`

--- a/notion/pages.go
+++ b/notion/pages.go
@@ -51,8 +51,8 @@ func (pm *PageManager) Create(ctx context.Context, parent ParentRef, properties 
 	log.CtxDebugf(ctx, "create page from parent: %+v", parent)
 
 	body := &struct {
-		Parent     ParentRef         `json:"parent"`
-		Properties json.RawMessage   `json:"properties"`
+		Parent     ParentRef       `json:"parent"`
+		Properties json.RawMessage `json:"properties"`
 	}{
 		Parent:     parent,
 		Properties: PropertyArray(properties).ForUpdate(),

--- a/notion/pages.go
+++ b/notion/pages.go
@@ -1,211 +1,94 @@
 package notion
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"strconv"
 
-	"golang.org/x/time/rate"
-
-	"github.com/tr1v3r/pkg/fetch"
 	"github.com/tr1v3r/pkg/log"
 )
 
-// NewPageManager return a new page manager
-func NewPageManager(version, token string) *PageManager {
-	return &PageManager{baseInfo: &baseInfo{
-		NotionVersion: version,
-		BearerToken:   token,
-	}, ctx: context.Background(), limiter: rate.NewLimiter(rateLimit, 4*rateLimit)}
-}
-
-// PageManager ...
+// PageManager implements PageAPI.
 type PageManager struct {
-	*baseInfo
-
-	ctx     context.Context
-	id      string
-	limiter *rate.Limiter
+	client *notionClient
 }
 
-// WithContext set Context
-func (pm PageManager) WithContext(ctx context.Context) *PageManager {
-	pm.ctx = ctx
-	return &pm
-}
-
-// WithID set page id
-func (pm PageManager) WithID(id string) *PageManager {
-	pm.id = id
-	return &pm
-}
-
-// WithLimiter with limiiter
-func (pm PageManager) WithLimiter(limiter *rate.Limiter) *PageManager {
-	pm.limiter = limiter
-	return &pm
-}
-
-// ID get page id
-func (pm *PageManager) ID() string {
-	return pm.id
-}
-
-// Retrieve retrieve a page
-// docs: https://developers.notion.com/reference/retrieve-a-page
-func (pm *PageManager) Retrieve() (*Object, error) {
-	log.CtxDebugf(pm.ctx, "retrieve page %s", pm.id)
-
-	_ = pm.limiter.Wait(pm.ctx)
-	resp, err := fetch.CtxGet(pm.ctx, pm.api(retrieveOp), pm.Headers()...)
-	if err != nil {
-		return nil, fmt.Errorf("request api fail: %w", err)
+// NewPageManager creates a PageManager with default settings.
+func NewPageManager(version, token string) *PageManager {
+	return &PageManager{
+		client: newNotionClient(version, token, defaultLimiter()),
 	}
-	log.CtxDebugf(pm.ctx, "retrieve page got response %s", string(resp))
-
-	var obj Object
-	if err := json.Unmarshal(resp, &obj); err != nil {
-		return nil, fmt.Errorf("unmarshal response fail: %w", err)
-	}
-	return &obj, nil
 }
 
-// RetrieveProp retrieve page property item
-// docs: https://developers.notion.com/reference/retrieve-a-page-property
-func (pm *PageManager) RetrieveProp(propID string) (*Object, error) {
-	log.CtxDebugf(pm.ctx, "retrieve page %s property %s", pm.id, propID)
+// Retrieve retrieves a page by ID.
+// GET /v1/pages/{page_id}
+func (pm *PageManager) Retrieve(ctx context.Context, id string) (*Page, error) {
+	log.CtxDebugf(ctx, "retrieve page %s", id)
 
-	const pageSize = 30
-	param := url.Values{}
-	param.Set("page_size", strconv.Itoa(pageSize))
-
-	var obj, results = new(Object), make([]Object, 0, 2*pageSize)
-	for obj.HasMore = true; obj.HasMore; {
-		if obj.NextCursor != "" {
-			param.Set("start_cursor", obj.NextCursor)
-		}
-
-		_ = pm.limiter.Wait(pm.ctx)
-		resp, err := fetch.CtxGet(pm.ctx, pm.api(retrievePropOp)+propID+"?"+param.Encode(), pm.Headers()...)
-		if err != nil {
-			return nil, fmt.Errorf("request api fail: %w", err)
-		}
-		log.CtxDebugf(pm.ctx, "retrieve page property got response %s", string(resp))
-
-		if err := json.Unmarshal(resp, obj); err != nil {
-			return nil, fmt.Errorf("unmarshal response fail: %w", err)
-		}
-
-		results = append(results, obj.Results...)
+	var page Page
+	if err := pm.client.get(ctx, "/pages/"+id, &page); err != nil {
+		return nil, fmt.Errorf("retrieve page %s: %w", id, err)
 	}
-	obj.Results = results
-	return obj, nil
+	return &page, nil
 }
 
-// Create create page
-// docs: https://developers.notion.com/reference/post-page
-// POST https://api.notion.com/v1/pages
-func (pm *PageManager) Create(parent PageItem, properties ...*Property) error {
-	log.CtxDebugf(pm.ctx, "create page from parent: %+v", parent)
+// RetrieveProperty retrieves a page property item, handling pagination automatically.
+// GET /v1/pages/{page_id}/properties/{property_id}
+func (pm *PageManager) RetrieveProperty(ctx context.Context, pageID, propertyID string) (*Property, error) {
+	log.CtxDebugf(ctx, "retrieve page %s property %s", pageID, propertyID)
 
-	payload, _ := json.Marshal(&struct {
-		Parent     PageItem `json:"parent"`
-		Properties any      `json:"properties"`
+	path := "/pages/" + pageID + "/properties/" + propertyID
+	var prop Property
+	if err := pm.client.get(ctx, path, &prop); err != nil {
+		return nil, fmt.Errorf("retrieve property %s/%s: %w", pageID, propertyID, err)
+	}
+	return &prop, nil
+}
+
+// Create creates a new page.
+// POST /v1/pages
+func (pm *PageManager) Create(ctx context.Context, parent ParentRef, properties ...*Property) (*Page, error) {
+	log.CtxDebugf(ctx, "create page from parent: %+v", parent)
+
+	body := &struct {
+		Parent     ParentRef         `json:"parent"`
+		Properties json.RawMessage   `json:"properties"`
 	}{
 		Parent:     parent,
 		Properties: PropertyArray(properties).ForUpdate(),
-	})
-	_ = pm.limiter.Wait(pm.ctx)
-	statusCode, resp, _, err := fetch.DoRequestWithOptions("POST", pm.api(createOp),
-		append(pm.Headers(), fetch.WithContext(pm.ctx)), bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("request api fail: %w", err)
 	}
 
-	if statusCode == 429 {
-		return ErrRateLimited
+	var page Page
+	if err := pm.client.post(ctx, "/pages", body, &page); err != nil {
+		return nil, fmt.Errorf("create page: %w", err)
 	}
-	if statusCode != 200 {
-		return fmt.Errorf("response error: [%d] %s", statusCode, string(resp))
-	}
-	return nil
+	return &page, nil
 }
 
-// Update update page
-// docs: https://developers.notion.com/reference/patch-page
-// PATCH https://api.notion.com/v1/pages/{page_id}
-func (pm *PageManager) Update(properties ...*Property) error {
-	log.CtxDebugf(pm.ctx, "update page %s", pm.id)
+// Update updates page properties.
+// PATCH /v1/pages/{page_id}
+func (pm *PageManager) Update(ctx context.Context, id string, properties ...*Property) (*Page, error) {
+	log.CtxDebugf(ctx, "update page %s", id)
 
-	payload, _ := json.Marshal(map[string]any{"properties": PropertyArray(properties).ForUpdate()})
-	log.CtxDebugf(pm.ctx, "update page with payload: %s", string(payload))
+	body := map[string]any{"properties": PropertyArray(properties).ForUpdate()}
 
-	_ = pm.limiter.Wait(pm.ctx)
-	resp, err := fetch.CtxPatch(pm.ctx, pm.api(updateOp), bytes.NewReader(payload), pm.Headers()...)
-	if err != nil {
-		return fmt.Errorf("request api fail: %w", err)
+	var page Page
+	if err := pm.client.patch(ctx, "/pages/"+id, body, &page); err != nil {
+		return nil, fmt.Errorf("update page %s: %w", id, err)
 	}
-	log.CtxDebugf(pm.ctx, "update page got response %s", string(resp))
-
-	var obj Object
-	if err := json.Unmarshal(resp, &obj); err != nil {
-		return fmt.Errorf("unmarshal response fail: %w", err)
-	}
-	// {"object":"error","status":401,"code":"unauthorized","message":"API token is invalid."}
-	if obj.Object == ErrorObjectType {
-		if obj.Status == 429 {
-			return ErrRateLimited
-		}
-		return fmt.Errorf("response error: [%d / %s] %s", obj.Status, obj.Code, obj.Message)
-	}
-	return nil
+	return &page, nil
 }
 
-// Trash trash a page
-// https://developers.notion.com/reference/archive-a-page
-func (pm *PageManager) Trash() error {
-	log.CtxDebugf(pm.ctx, "trash page %s", pm.id)
+// Trash moves a page to trash.
+// PATCH /v1/pages/{page_id} with in_trash: true
+func (pm *PageManager) Trash(ctx context.Context, id string) (*Page, error) {
+	log.CtxDebugf(ctx, "trash page %s", id)
 
-	// archived or in_trash
-	payload, _ := json.Marshal(map[string]any{"in_trash": true})
+	body := map[string]any{"in_trash": true}
 
-	_ = pm.limiter.Wait(pm.ctx)
-	resp, err := fetch.CtxPatch(pm.ctx, pm.api(updateOp), bytes.NewReader(payload), pm.Headers()...)
-	if err != nil {
-		return fmt.Errorf("request api fail: %w", err)
+	var page Page
+	if err := pm.client.patch(ctx, "/pages/"+id, body, &page); err != nil {
+		return nil, fmt.Errorf("trash page %s: %w", id, err)
 	}
-	log.CtxDebugf(pm.ctx, "trash page got response %s", string(resp))
-
-	var obj Object
-	if err := json.Unmarshal(resp, &obj); err != nil {
-		return fmt.Errorf("unmarshal response fail: %w", err)
-	}
-	// {"object":"error","status":401,"code":"unauthorized","message":"API token is invalid."}
-	if obj.Object == ErrorObjectType {
-		if obj.Status == 429 {
-			return ErrRateLimited
-		}
-		return fmt.Errorf("response error: [%d / %s] %s", obj.Status, obj.Code, obj.Message)
-	}
-	return nil
-}
-
-// api return page api
-func (pm *PageManager) api(typ operateType) string {
-	baseAPI := notionAPI() + "/pages"
-	switch typ {
-	case createOp: // POST https://api.notion.com/v1/pages
-		return baseAPI
-	case retrieveOp: // GET https://api.notion.com/v1/pages/{page_id}
-		return baseAPI + "/" + pm.id
-	case retrievePropOp: // GET https://api.notion.com/v1/pages/{page_id}/properties/{property_id}
-		return baseAPI + "/" + pm.id + "/properties/"
-	case updateOp: // PATCH https://api.notion.com/v1/pages/{page_id}
-		return baseAPI + "/" + pm.id
-	default:
-		return ""
-	}
+	return &page, nil
 }

--- a/notion/property.go
+++ b/notion/property.go
@@ -59,7 +59,7 @@ func (p Property) ForUpdate() (data json.RawMessage) {
 	case p.Files != nil:
 		data, _ = json.Marshal(map[PropertyType]json.RawMessage{FilesProp: p.Files})
 	case p.URL != nil:
-		data, _ = json.Marshal(map[PropertyType]string{URLProp: string(p.URL)})
+		data, _ = json.Marshal(map[PropertyType]json.RawMessage{URLProp: p.URL})
 	case p.Checkbox != nil:
 		data, _ = json.Marshal(map[PropertyType]bool{CheckboxProp: *p.Checkbox})
 	case p.Relation != nil:

--- a/notion/property_test.go
+++ b/notion/property_test.go
@@ -1,0 +1,244 @@
+package notion
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProperty_ForUpdate_Date(t *testing.T) {
+	dateJSON := DateObject{Start: "2024-01-15", End: "2024-01-20"}.JSON()
+	p := Property{Name: "Due Date", Type: DateProp, Date: dateJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(DateProp))
+
+	var dateObj DateObject
+	err = json.Unmarshal(result[string(DateProp)], &dateObj)
+	assert.NoError(t, err)
+	assert.Equal(t, "2024-01-15", dateObj.Start)
+	assert.Equal(t, "2024-01-20", dateObj.End)
+}
+
+func TestProperty_ForUpdate_Title(t *testing.T) {
+	titleJSON := TextObjectArray{
+		{Text: TextItem{Content: "Hello"}, PlainText: "Hello"},
+	}.JSON()
+	p := Property{Name: "Name", Type: TitleProp, Title: titleJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(TitleProp))
+}
+
+func TestProperty_ForUpdate_RichText(t *testing.T) {
+	rtJSON := TextObjectArray{
+		{Text: TextItem{Content: "world"}, PlainText: "world"},
+	}.JSON()
+	p := Property{Name: "Desc", Type: RichTextProp, RichText: rtJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(RichTextProp))
+}
+
+func TestProperty_ForUpdate_Number(t *testing.T) {
+	p := Property{Name: "Count", Type: NumberProp, Number: 42}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]any
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(NumberProp))
+	assert.Equal(t, float64(42), result[string(NumberProp)])
+}
+
+func TestProperty_ForUpdate_Select(t *testing.T) {
+	selJSON := SelectOptionObject{Name: "High", Color: "red"}.JSON()
+	p := Property{Name: "Priority", Type: SelectProp, Select: selJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(SelectProp))
+
+	var selObj SelectOptionObject
+	err = json.Unmarshal(result[string(SelectProp)], &selObj)
+	assert.NoError(t, err)
+	assert.Equal(t, "High", selObj.Name)
+}
+
+func TestProperty_ForUpdate_MultiSelect(t *testing.T) {
+	multiJSON, _ := json.Marshal([]SelectOptionObject{
+		{Name: "Go"},
+		{Name: "Python"},
+	})
+	p := Property{Name: "Tags", Type: MultiSelectProp, MultiSelect: multiJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(MultiSelectProp))
+
+	var options []SelectOptionObject
+	err = json.Unmarshal(result[string(MultiSelectProp)], &options)
+	assert.NoError(t, err)
+	assert.Len(t, options, 2)
+	assert.Equal(t, "Go", options[0].Name)
+	assert.Equal(t, "Python", options[1].Name)
+}
+
+func TestProperty_ForUpdate_Checkbox(t *testing.T) {
+	checked := true
+	p := Property{Name: "Done", Type: CheckboxProp, Checkbox: &checked}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]any
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(CheckboxProp))
+	assert.Equal(t, true, result[string(CheckboxProp)])
+}
+
+func TestProperty_ForUpdate_URL(t *testing.T) {
+	urlJSON, _ := json.Marshal("https://example.com")
+	p := Property{Name: "Link", Type: URLProp, URL: urlJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(URLProp))
+
+	// Verify no double-serialization: the URL value should be a string, not a string within a string
+	var urlStr string
+	err = json.Unmarshal(result[string(URLProp)], &urlStr)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com", urlStr)
+}
+
+func TestProperty_ForUpdate_Relation(t *testing.T) {
+	relJSON := RelationObject{{ID: "abc-123"}, {ID: "def-456"}}.JSON()
+	p := Property{Name: "Related", Type: RelationProp, Relation: relJSON}
+
+	data := p.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, string(RelationProp))
+}
+
+func TestProperty_PlainText_RichText(t *testing.T) {
+	rtJSON := TextObjectArray{
+		{PlainText: "Hello "},
+		{PlainText: "World"},
+	}.JSON()
+	p := Property{Type: RichTextProp, RichText: rtJSON}
+
+	assert.Equal(t, "Hello World", p.PlainText())
+}
+
+func TestProperty_PlainText_Title(t *testing.T) {
+	titleJSON := TextObjectArray{
+		{PlainText: "My Page Title"},
+	}.JSON()
+	p := Property{Type: TitleProp, Title: titleJSON}
+
+	assert.Equal(t, "My Page Title", p.PlainText())
+}
+
+func TestProperty_PlainText_Select(t *testing.T) {
+	selJSON := SelectOptionObject{Name: "Medium"}.JSON()
+	p := Property{Type: SelectProp, Select: selJSON}
+
+	assert.Equal(t, "Medium", p.PlainText())
+}
+
+func TestProperty_PlainText_URL(t *testing.T) {
+	urlJSON, _ := json.Marshal("https://example.com/page")
+	p := Property{Type: URLProp, URL: urlJSON}
+
+	assert.Equal(t, "https://example.com/page", p.PlainText())
+}
+
+func TestProperty_PlainText_Empty(t *testing.T) {
+	// Nil rich text returns empty
+	p1 := Property{Type: RichTextProp, RichText: nil}
+	assert.Equal(t, "", p1.PlainText())
+
+	// Nil title returns empty
+	p2 := Property{Type: TitleProp, Title: nil}
+	assert.Equal(t, "", p2.PlainText())
+
+	// Unsupported type returns empty
+	p3 := Property{Type: FilesProp}
+	assert.Equal(t, "", p3.PlainText())
+
+	// Nil select returns empty
+	p4 := Property{Type: SelectProp, Select: nil}
+	assert.Equal(t, "", p4.PlainText())
+}
+
+func TestProperty_GetRelationIDs(t *testing.T) {
+	relJSON := RelationObject{{ID: "abc-123"}, {ID: "def-456"}, {ID: "ghi-789"}}.JSON()
+	p := Property{Type: RelationProp, Relation: relJSON}
+
+	ids := p.GetRelationIDs()
+	assert.Equal(t, []string{"abc-123", "def-456", "ghi-789"}, ids)
+}
+
+func TestProperty_GetRelationIDs_Nil(t *testing.T) {
+	p := Property{Type: RelationProp, Relation: nil}
+	assert.Nil(t, p.GetRelationIDs())
+}
+
+func TestPropertyArray_ForUpdate(t *testing.T) {
+	titleJSON := TextObjectArray{{PlainText: "Test Title"}}.JSON()
+	checked := false
+	urlJSON, _ := json.Marshal("https://example.org")
+
+	pa := PropertyArray{
+		{Name: "Title", Type: TitleProp, Title: titleJSON},
+		{Name: "Done", Type: CheckboxProp, Checkbox: &checked},
+		{Name: "Link", Type: URLProp, URL: urlJSON},
+	}
+
+	data := pa.ForUpdate()
+	assert.NotNil(t, data)
+
+	var result map[string]json.RawMessage
+	err := json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Contains(t, result, "Title")
+	assert.Contains(t, result, "Done")
+	assert.Contains(t, result, "Link")
+}

--- a/notion/search.go
+++ b/notion/search.go
@@ -2,34 +2,39 @@ package notion
 
 import (
 	"context"
+	"fmt"
 
-	"golang.org/x/time/rate"
+	"github.com/tr1v3r/pkg/log"
 )
 
-// NewSearchManager return a new search manager
-func NewSearchManager(version, token string) *SearchManager {
-	return &SearchManager{baseInfo: &baseInfo{
-		NotionVersion: version,
-		BearerToken:   token,
-	}, ctx: context.Background()}
-}
-
-// SearchManager ...
+// SearchManager implements SearchAPI.
 type SearchManager struct {
-	*baseInfo
-
-	ctx     context.Context
-	limiter *rate.Limiter
+	client *notionClient
 }
 
-// WithContext set Context
-func (sm SearchManager) WithContext(ctx context.Context) *SearchManager {
-	sm.ctx = ctx
-	return &sm
+// NewSearchManager creates a SearchManager with default settings.
+func NewSearchManager(version, token string) *SearchManager {
+	return &SearchManager{
+		client: newNotionClient(version, token, defaultLimiter()),
+	}
 }
 
-// WithLimiter with limiiter
-func (sm SearchManager) WithLimiter(limiter *rate.Limiter) *SearchManager {
-	sm.limiter = limiter
-	return &sm
+// Search searches pages and databases in the workspace.
+// POST /v1/search
+func (sm *SearchManager) Search(ctx context.Context, query string, filter *SearchFilter) (*ListResponse[SearchResult], error) {
+	log.CtxDebugf(ctx, "search: %s", query)
+
+	body := map[string]any{}
+	if query != "" {
+		body["query"] = query
+	}
+	if filter != nil {
+		body["filter"] = filter
+	}
+
+	var resp ListResponse[SearchResult]
+	if err := sm.client.post(ctx, "/search", body, &resp); err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	return &resp, nil
 }

--- a/notion/types.go
+++ b/notion/types.go
@@ -1,0 +1,196 @@
+package notion
+
+import "encoding/json"
+
+// Database represents a Notion database object.
+type Database struct {
+	Object         string             `json:"object"`
+	ID             string             `json:"id"`
+	CreatedTime    string             `json:"created_time"`
+	CreatedBy      UserRef            `json:"created_by"`
+	LastEditedTime string             `json:"last_edited_time"`
+	LastEditedBy   UserRef            `json:"last_edited_by"`
+	Title          []TextObject       `json:"title,omitempty"`
+	Description    []TextObject       `json:"description,omitempty"`
+	IsInline       bool               `json:"is_inline,omitempty"`
+	Properties     map[string]Property `json:"properties,omitempty"`
+	Parent         ParentRef          `json:"parent,omitempty"`
+	URL            string             `json:"url,omitempty"`
+	Icon           *IconItem          `json:"icon,omitempty"`
+	Cover          *FileItem          `json:"cover,omitempty"`
+}
+
+// Page represents a Notion page object.
+type Page struct {
+	Object         string             `json:"object"`
+	ID             string             `json:"id"`
+	CreatedTime    string             `json:"created_time"`
+	CreatedBy      UserRef            `json:"created_by"`
+	LastEditedTime string             `json:"last_edited_time"`
+	LastEditedBy   UserRef            `json:"last_edited_by"`
+	Parent         ParentRef          `json:"parent,omitempty"`
+	Properties     map[string]Property `json:"properties,omitempty"`
+	URL            string             `json:"url,omitempty"`
+	Archived       bool               `json:"archived,omitempty"`
+	InTrash        bool               `json:"in_trash,omitempty"`
+	Icon           *IconItem          `json:"icon,omitempty"`
+	Cover          *FileItem          `json:"cover,omitempty"`
+}
+
+// Block represents a Notion block object.
+type Block struct {
+	Object         string          `json:"object"`
+	ID             string          `json:"id"`
+	Parent         ParentRef       `json:"parent,omitempty"`
+	Type           string          `json:"type"`
+	CreatedTime    string          `json:"created_time"`
+	CreatedBy      UserRef         `json:"created_by"`
+	LastEditedTime string          `json:"last_edited_time"`
+	LastEditedBy   UserRef         `json:"last_edited_by"`
+	HasChildren    bool            `json:"has_children"`
+	InTrash        bool            `json:"in_trash,omitempty"`
+
+	Paragraph        *RichTextBlock `json:"paragraph,omitempty"`
+	Heading1         *RichTextBlock `json:"heading_1,omitempty"`
+	Heading2         *RichTextBlock `json:"heading_2,omitempty"`
+	Heading3         *RichTextBlock `json:"heading_3,omitempty"`
+	BulletedListItem *RichTextBlock `json:"bulleted_list_item,omitempty"`
+	NumberedListItem *RichTextBlock `json:"numbered_list_item,omitempty"`
+	ToDo             *ToDoBlock     `json:"to_do,omitempty"`
+	Toggle           *RichTextBlock `json:"toggle,omitempty"`
+	Code             *CodeBlock     `json:"code,omitempty"`
+	Quote            *RichTextBlock `json:"quote,omitempty"`
+	Callout          *CalloutBlock  `json:"callout,omitempty"`
+	Divider          *struct{}      `json:"divider,omitempty"`
+	Embed            *EmbedBlock    `json:"embed,omitempty"`
+	Image            *FileBlock     `json:"image,omitempty"`
+	Video            *FileBlock     `json:"video,omitempty"`
+	Bookmark         *BookmarkBlock `json:"bookmark,omitempty"`
+	TableOfContents  *struct {
+		Color string `json:"color,omitempty"`
+	} `json:"table_of_contents,omitempty"`
+	ChildPage      *ChildPageBlock `json:"child_page,omitempty"`
+	ChildDatabase  *ChildDBBlock   `json:"child_database,omitempty"`
+}
+
+// RichTextBlock is a block that contains rich text content.
+type RichTextBlock struct {
+	RichText []TextObject `json:"rich_text"`
+	Color    string       `json:"color,omitempty"`
+	IsToggleable bool     `json:"is_toggleable,omitempty"`
+}
+
+// ToDoBlock is a checkbox block.
+type ToDoBlock struct {
+	RichText []TextObject `json:"rich_text"`
+	Checked  bool         `json:"checked"`
+	Color    string       `json:"color,omitempty"`
+}
+
+// CodeBlock is a code block with language.
+type CodeBlock struct {
+	RichText []TextObject `json:"rich_text"`
+	Language string       `json:"language"`
+}
+
+// CalloutBlock is a callout block with icon.
+type CalloutBlock struct {
+	RichText []TextObject `json:"rich_text"`
+	Icon     *IconItem    `json:"icon,omitempty"`
+	Color    string       `json:"color,omitempty"`
+}
+
+// EmbedBlock is an embedded URL block.
+type EmbedBlock struct {
+	URL string `json:"url"`
+}
+
+// FileBlock represents an image, video, audio, or file block.
+type FileBlock struct {
+	Type     string       `json:"type"`
+	External *FileRef     `json:"external,omitempty"`
+	File     *HostedFile  `json:"file,omitempty"`
+	Caption  []TextObject `json:"caption,omitempty"`
+}
+
+// FileRef is an external file reference.
+type FileRef struct {
+	URL string `json:"url"`
+}
+
+// HostedFile is a Notion-hosted file with expiry.
+type HostedFile struct {
+	URL        string `json:"url"`
+	ExpiryTime string `json:"expiry_time"`
+}
+
+// BookmarkBlock is a bookmark block.
+type BookmarkBlock struct {
+	URL     string       `json:"url"`
+	Caption []TextObject `json:"caption,omitempty"`
+}
+
+// ChildPageBlock represents a nested page reference.
+type ChildPageBlock struct {
+	Title string `json:"title"`
+}
+
+// ChildDBBlock represents a nested database reference.
+type ChildDBBlock struct {
+	Title string `json:"title"`
+}
+
+// User represents a Notion user.
+type User struct {
+	Object    string `json:"object"`
+	ID        string `json:"id"`
+	Type      string `json:"type,omitempty"`
+	Name      string `json:"name,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	Email     string `json:"email,omitempty"`
+}
+
+// UserRef is a lightweight user reference in created_by/last_edited_by fields.
+type UserRef struct {
+	Object string `json:"object"`
+	ID     string `json:"id"`
+}
+
+// Comment represents a Notion comment.
+type Comment struct {
+	Object         string       `json:"object"`
+	ID             string       `json:"id"`
+	Parent         ParentRef    `json:"parent,omitempty"`
+	DiscussionID   string       `json:"discussion_id,omitempty"`
+	CreatedTime    string       `json:"created_time"`
+	LastEditedTime string       `json:"last_edited_time,omitempty"`
+	CreatedBy      UserRef      `json:"created_by"`
+	RichText       []TextObject `json:"rich_text"`
+}
+
+// ParentRef references a parent resource (page, database, or workspace).
+type ParentRef = PageItem
+
+// ListResponse is a generic paginated response.
+type ListResponse[T any] struct {
+	Object     string `json:"object"`
+	Results    []T    `json:"results"`
+	NextCursor string `json:"next_cursor"`
+	HasMore    bool   `json:"has_more"`
+	Type       string `json:"type,omitempty"`
+}
+
+// SearchResult is a result from the Notion search API.
+type SearchResult = json.RawMessage
+
+// SearchFilter filters search results.
+type SearchFilter struct {
+	Property string `json:"property"`
+	Value    string `json:"value"`
+}
+
+// SearchSort sorts search results.
+type SearchSort struct {
+	Direction string `json:"direction"`
+	Timestamp string `json:"timestamp"`
+}

--- a/notion/users.go
+++ b/notion/users.go
@@ -1,0 +1,54 @@
+package notion
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tr1v3r/pkg/log"
+)
+
+// UserManager implements UserAPI.
+type UserManager struct {
+	client *notionClient
+}
+
+// NewUserManager creates a UserManager with default settings.
+func NewUserManager(version, token string) *UserManager {
+	return &UserManager{
+		client: newNotionClient(version, token, defaultLimiter()),
+	}
+}
+
+// Me retrieves the current authenticated bot user.
+// GET /v1/users/me
+func (um *UserManager) Me(ctx context.Context) (*User, error) {
+	log.CtxDebugf(ctx, "retrieve current user")
+
+	var user User
+	if err := um.client.get(ctx, "/users/me", &user); err != nil {
+		return nil, fmt.Errorf("retrieve current user: %w", err)
+	}
+	return &user, nil
+}
+
+// Retrieve retrieves a user by ID.
+// GET /v1/users/{user_id}
+func (um *UserManager) Retrieve(ctx context.Context, id string) (*User, error) {
+	log.CtxDebugf(ctx, "retrieve user %s", id)
+
+	var user User
+	if err := um.client.get(ctx, "/users/"+id, &user); err != nil {
+		return nil, fmt.Errorf("retrieve user %s: %w", id, err)
+	}
+	return &user, nil
+}
+
+// List retrieves all users in the workspace.
+// GET /v1/users
+func (um *UserManager) List(ctx context.Context) ([]User, error) {
+	log.CtxDebugf(ctx, "list users")
+
+	return paginateAll[User](ctx, um.client, "GET", "/users", func(cursor string) any {
+		return &ListOptions{PageSize: 100, Cursor: cursor}
+	})
+}


### PR DESCRIPTION
## Summary

- **Architecture overhaul**: Replace god `Object` struct with typed responses (`Database`, `Page`, `Block`, `User`, `Comment`), introduce `notionClient` for centralized HTTP/rate-limiting/error-handling, define 6 interfaces (`DatabaseAPI`, `PageAPI`, `BlockAPI`, `UserAPI`, `SearchAPI`, `CommentAPI`) for mockability
- **New APIs**: Full `BlockManager` (Retrieve/Update/Delete/Children/AppendChildren), full `SearchManager` (Search), new `UserManager` (Me/Retrieve/List), new `CommentManager` (List/Create)
- **Bug fixes**: Channel leak in asyncQuery, limiter error suppression, URL injection in RetrieveProp, condition mutation, copy-paste error messages, URL double-serialization in ForUpdate
- **Testing**: 84 unit tests covering all API methods, property serialization, filter marshaling, error handling, context cancellation

## Breaking Changes

- Context is now the first parameter to all methods (Go idiom)
- `Create` methods return the created object (`(*T, error)` instead of `error`)
- `Manager` fields are interface types instead of embedded concrete structs

## Test plan

- [x] `go build ./notion/...` compiles cleanly
- [x] `go vet ./notion/...` passes
- [x] 84 unit tests pass with mock HTTP server
- [ ] Integration tests pass with real Notion API credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)